### PR TITLE
Backtest Window: Added start date, end date. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ Subclass `Strategy` and implement the three abstract methods the backtester call
 Example:
 
 ```python
-from datetime import timedelta
-from hqg_algorithms import Strategy, Cadence, Slice, PortfolioView
+from datetime import date, timedelta
+from hqg_algorithms import Strategy, BacktestWindow, Cadence, Slice, PortfolioView
 
 
 class BuyAndRebalanceSpyIef(Strategy):
     def universe(self) -> list[str]:
         return ["SPY", "IEF"]
+
+    def backtest_window(self) -> BacktestWindow:
+        return BacktestWindow(date(2010, 1, 1), date(2024, 12, 31))
 
     def cadence(self) -> Cadence:
         return Cadence( 
@@ -37,6 +40,7 @@ class BuyAndRebalanceSpyIef(Strategy):
 
 Key lifecycle methods:
 - `universe()` tells the platform which symbols to load.
+- `backtest_window()` sets mandatory start/end dates for the backtest.
 - `cadence()` specifies call frequency, trigger phase, and execution lag.
 - `on_data(data, portfolio)` returns target portfolio weights, `{}` for all cash, or `None` to skip an update.
 

--- a/hqg_algorithms/strategy.py
+++ b/hqg_algorithms/strategy.py
@@ -1,6 +1,6 @@
 """strategy.py"""
 from abc import ABC, abstractmethod
-from hqg_algorithms.types import Cadence, Slice, PortfolioView
+from hqg_algorithms.types import BacktestWindow, Cadence, Slice, PortfolioView
 
 class Strategy(ABC):
     """
@@ -8,13 +8,15 @@ class Strategy(ABC):
 
     Each subclass defines:
       - The asset universe it trades.
+            - The backtest window (mandatory start/end dates).
       - The cadence (how often it's called and when trades execute).
       - The trading logic that converts data into target portfolio weights.
 
     The backtester calls:
       1. strategy.universe() to know what tickers to load.
-      2. strategy.cadence() to schedule on_data calls.
-      3. strategy.on_data(t, slice_) each time new data arrives.
+    2. strategy.backtest_window() to set the start/end date range.
+    3. strategy.cadence() to schedule on_data calls.
+    4. strategy.on_data(t, slice_) each time new data arrives.
     """
 
     def __init__(self) -> None:
@@ -29,6 +31,17 @@ class Strategy(ABC):
             return ["SPY", "IEF", "GLD"]
 
         Used by the backtester to determine what data to load.
+        """
+
+    @abstractmethod
+    def backtest_window(self) -> BacktestWindow:
+        """
+        Return a BacktestWindow with mandatory start and end dates.
+
+        Example:
+            return BacktestWindow(date(2010, 1, 1), date(2024, 12, 31))
+
+        Used by the backtester to constrain the historical data window.
         """
 
     @abstractmethod

--- a/hqg_algorithms/types.py
+++ b/hqg_algorithms/types.py
@@ -1,6 +1,6 @@
 """types.py"""
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import date, timedelta
 from typing import Optional
 
 @dataclass(frozen=True)
@@ -9,6 +9,13 @@ class Cadence:
     bar_size: timedelta = timedelta(days=1)
     call_phase: str = "on_bar_close"   # or "on_bar_open"
     exec_lag_bars: int = 1             # bars between signal and execution
+
+
+@dataclass(frozen=True)
+class BacktestWindow:
+    """Defines the mandatory start/end date for a strategy's backtest."""
+    start_date: date
+    end_date: date
 
 
 class Slice(dict[str, dict[str, float]]):


### PR DESCRIPTION
I believe we're missing the option to include a start date and end date. I made a new BacktestWindow. 

Use like this: 
`
def backtest_window(self) -> BacktestWindow:
        return BacktestWindow(date(2010, 1, 1), date(2024, 12, 31))
`