### PR TITLE
v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 *.egg-info/
 build/
 dist/
+tests/
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ __pycache__/
 *.egg-info/
 build/
 dist/
-tests/
 .venv

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ class BuyAndRebalance(Strategy):
 
 ### Important constraints
 
-- `universe` **must** be a non-empty list literal of ticker strings (e.g. `["SPY", "IEF"]`). Variables, function calls, and concatenation are not supported.
-- `cadence` **must** be a direct `Cadence(...)` call with `BarSize.X` and/or `ExecutionTiming.Y` keyword arguments. If omitted, it defaults to `Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_CLOSE)`.
+- `universe` **must** be a non-empty list literal of ticker strings (e.g. `["SPY", "IEF"]`). Variables, function calls, and concatenation are not supported. Tickers are normalized to uppercase and deduplicated. Empty strings, whitespace-only tickers, and tickers exceeding 12 characters are rejected. Maximum universe size is 200.
+- `cadence` **must** be a direct `Cadence(...)` call with `BarSize.X` and/or `ExecutionTiming.Y` keyword arguments. Positional arguments and unknown keyword arguments are rejected. If omitted, it defaults to `Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_CLOSE)`.
+- Both `universe` and `cadence` are fixed at class definition and cannot be changed at runtime.
 
 `Slice` maps each symbol to a `Bar` dataclass with typed fields (`open`, `high`, `low`, `close`, `volume`). You can access prices via helpers like `data.close("SPY")`, or grab the full bar with `data.bar("SPY")` for direct attribute access. `PortfolioView` gives read-only access to current equity, cash, positions, and weights.
 
@@ -49,7 +50,7 @@ class BuyAndRebalance(Strategy):
 | `CLOSE_TO_CLOSE` | Bar close | Same bar's close (DEFAULT) |
 | `CLOSE_TO_NEXT_OPEN` | Bar close | Next bar's open |
 
-`CLOSE_TO_NEXT_OPEN` is the most realistic for intradaily strategies since it avoids look-ahead bias - your signal only uses data that was already available before the trade executes. The other two modes assume you can observe a price and trade at that same price.
+`CLOSE_TO_NEXT_OPEN` is the most realistic for intraday strategies since it avoids look-ahead bias - your signal only uses data that was already available before the trade executes.
 
 ### Signal types
 
@@ -61,12 +62,16 @@ class BuyAndRebalance(Strategy):
 | `Hold()` | Keep the current allocation unchanged. |
 | `Liquidate()` | Sell all positions and move fully to cash. |
 
-## Validating strategies
+## Validating and parsing strategies
 
-Use `validate_strategy` to check strategy source code without executing it. It parses the code with `ast` and verifies that `universe`, `cadence`, and `on_data` are declared correctly (in a way that services expect).
+The `parsing` module provides two functions for working with strategy source code without executing it. Both use AST parsing - no user code is ever run.
+
+### `validate_strategy`
+
+Checks strategy source code and returns a list of error strings. An empty list means the strategy is valid.
 
 ```python
-from hqg_algorithms.validate import validate_strategy
+from hqg_algorithms import validate_strategy
 
 source = open("my_strategy.py").read()
 errors = validate_strategy(source)
@@ -78,17 +83,38 @@ else:
     print("✅ Strategy is valid")
 ```
 
-`validate_strategy` returns a list of error strings - an empty list means the strategy is valid. It checks:
-
 | Check | Rule |
 | --- | --- |
 | **Syntax** | Source must be parseable Python |
-| **Strategy class** | At least one class must define a `universe` attribute |
-| **`universe`** | Must be a non-empty list literal containing only strings |
-| **`cadence`** | If present, must be a `Cadence(...)` call with valid `BarSize` / `ExecutionTiming` keyword args |
+| **Strategy class** | At least one class inheriting from `Strategy` must be present |
+| **`universe`** | Must be a non-empty list literal of valid ticker strings |
+| **`cadence`** | If present, must be a `Cadence(...)` call with valid keyword args only |
 | **`on_data`** | Must be defined as a method on the strategy class |
 
-This is useful for things like editor integrations or pre-submission validation in web UIs where you want fast feedback before sending code to a service.
+All errors are blocking - if `validate_strategy` returns anything, the strategy cannot run.
+
+### `get_strategy_metadata`
+
+Extracts `universe` and `cadence` as typed objects. Raises `ValueError` if the source is invalid.
+
+```python
+from hqg_algorithms import get_strategy_metadata
+
+meta = get_strategy_metadata(source)
+print(meta.universe)   # ["SPY", "IEF"] (normalized, deduplicated)
+print(meta.cadence)    # Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_CLOSE)
+```
+
+Returns a frozen `StrategyMetadata` dataclass:
+
+```python
+@dataclass(frozen=True)
+class StrategyMetadata:
+    universe: list[str]
+    cadence: Cadence
+```
+
+This is intended for services that need to know what a strategy requires (data subscriptions, scheduling) without loading it.
 
 ## Example - SMA crossover
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ class BuyAndRebalance(Strategy):
 
 | `ExecutionTiming` | `on_data` fires at | Trades fill at |
 | --- | --- | --- |
-| `CLOSE_TO_NEXT_OPEN` | Bar close | Next bar's open |
 | `CLOSE_TO_CLOSE` | Bar close | Same bar's close (DEFAULT) |
-| `OPEN_TO_OPEN` | Bar open | Same bar's open |
+| `CLOSE_TO_NEXT_OPEN` | Bar close | Next bar's open |
 
 `CLOSE_TO_NEXT_OPEN` is the most realistic for intradaily strategies since it avoids look-ahead bias - your signal only uses data that was already available before the trade executes. The other two modes assume you can observe a price and trade at that same price.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,35 @@ class BuyAndRebalance(Strategy):
 | `Hold()` | Keep the current allocation unchanged. |
 | `Liquidate()` | Sell all positions and move fully to cash. |
 
+## Validating strategies
+
+Use `validate_strategy` to check strategy source code without executing it. It parses the code with `ast` and verifies that `universe`, `cadence`, and `on_data` are declared correctly (in a way that services expect).
+
+```python
+from hqg_algorithms.validate import validate_strategy
+
+source = open("my_strategy.py").read()
+errors = validate_strategy(source)
+
+if errors:
+    for e in errors:
+        print(f"❌ {e}")
+else:
+    print("✅ Strategy is valid")
+```
+
+`validate_strategy` returns a list of error strings - an empty list means the strategy is valid. It checks:
+
+| Check | Rule |
+| --- | --- |
+| **Syntax** | Source must be parseable Python |
+| **Strategy class** | At least one class must define a `universe` attribute |
+| **`universe`** | Must be a non-empty list literal containing only strings |
+| **`cadence`** | If present, must be a `Cadence(...)` call with valid `BarSize` / `ExecutionTiming` keyword args |
+| **`on_data`** | Must be defined as a method on the strategy class |
+
+This is useful for things like editor integrations or pre-submission validation in web UIs where you want fast feedback before sending code to a service.
+
 ## Example - SMA crossover
 
 ```python

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Interfaces and helper types for writing HQG trading strategies.
 
 ## Install
+
 ```shell
 python3 -m pip install --upgrade pip setuptools wheel
 pip install hqg-algorithms
@@ -11,6 +12,7 @@ pip install hqg-algorithms
 ## Quick start
 
 Subclass `Strategy` and implement three methods:
+
 ```python
 from hqg_algorithms import (
     Strategy, Cadence, Slice, PortfolioView,
@@ -29,10 +31,10 @@ class BuyAndRebalance(Strategy):
 ```
 
 | Method | Purpose |
-|--------|---------|
+| -------- | --------- |
 | `universe()` | Symbols the platform loads for this strategy |
 | `cadence()` | Bar resolution and execution timing |
-| `on_data()` | Return target portfolio weights, `{}` for all cash, or `None` to skip an update |
+| `on_data()` | Return a `Signal`: `TargetWeights(...)`, `Hold()`, or `Liquidate()` |
 
 `Slice` maps each symbol to a `Bar` dataclass with typed fields (`open`, `high`, `low`, `close`, `volume`). You can access prices via helpers like `data.close("SPY")`, or grab the full bar with `data.bar("SPY")` for direct attribute access. `PortfolioView` gives read-only access to current equity, cash, positions, and weights.
 
@@ -41,7 +43,7 @@ class BuyAndRebalance(Strategy):
 `ExecutionTiming` controls when your strategy receives data and when the resulting trades fill. Pick the option that matches your signal logic:
 
 | `ExecutionTiming` | `on_data` fires at | Trades fill at |
-|---|---|---|---|
+| --- | --- | --- |
 | `CLOSE_TO_NEXT_OPEN` | Bar close | Next bar's open |
 | `CLOSE_TO_CLOSE` | Bar close | Same bar's close (DEFAULT) |
 | `OPEN_TO_OPEN` | Bar open | Same bar's open |
@@ -58,8 +60,8 @@ class BuyAndRebalance(Strategy):
 | `Hold()` | Keep the current allocation unchanged. |
 | `Liquidate()` | Sell all positions and move fully to cash. |
 
-
 ## Example — SMA crossover
+
 ```python
 from hqg_algorithms import (
     Strategy, Cadence, Slice, PortfolioView,

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class BuyAndRebalance(Strategy):
 | `cadence()` | Bar resolution, trigger timing, and execution delay |
 | `on_data()` | Return target portfolio weights, `{}` for all cash, or `None` to skip an update |
 
-`Slice` exposes helpers like `data.close("SPY")` to read prices. `PortfolioView` gives read-only access to current equity, cash, positions, and weights.
+`Slice` maps each symbol to a `Bar` dataclass with typed fields (`open`, `high`, `low`, `close`, `volume`). You can access prices via helpers like `data.close("SPY")`, or grab the full bar with `data.bar("SPY")` for direct attribute access. `PortfolioView` gives read-only access to current equity, cash, positions, and weights.
 
 ## Example — SMA crossover
 ```python

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install hqg-algorithms
 
 ## Quick start
 
-Subclass `Strategy` and implement three methods:
+Subclass `Strategy`, declare your `universe` and `cadence`, and implement `on_data`:
 
 ```python
 from hqg_algorithms import (
@@ -20,21 +20,23 @@ from hqg_algorithms import (
 )
 
 class BuyAndRebalance(Strategy):
-    def universe(self) -> list[str]:
-        return ["SPY", "IEF"]
-
-    def cadence(self) -> Cadence:
-        return Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
+    universe = ["SPY", "IEF"]
+    cadence = Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_CLOSE)
 
     def on_data(self, data: Slice, portfolio: PortfolioView) -> Signal:
         return TargetWeights({"SPY": 0.6, "IEF": 0.4})
 ```
 
-| Method | Purpose |
-| -------- | --------- |
-| `universe()` | Symbols the platform loads for this strategy |
-| `cadence()` | Bar resolution and execution timing |
-| `on_data()` | Return a `Signal`: `TargetWeights(...)`, `Hold()`, or `Liquidate()` |
+| Declaration | Purpose | Required? |
+| -------- | --------- | --------- |
+| `universe` | List of ticker strings the platform loads for this strategy | Yes |
+| `cadence` | Bar resolution and execution timing (optional - defaults to daily, close-to-close) | No |
+| `on_data()` | Return a `Signal`: `TargetWeights(...)`, `Hold()`, or `Liquidate()` | Yes |
+
+### Important constraints
+
+- `universe` **must** be a non-empty list literal of ticker strings (e.g. `["SPY", "IEF"]`). Variables, function calls, and concatenation are not supported.
+- `cadence` **must** be a direct `Cadence(...)` call with `BarSize.X` and/or `ExecutionTiming.Y` keyword arguments. If omitted, it defaults to `Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_CLOSE)`.
 
 `Slice` maps each symbol to a `Bar` dataclass with typed fields (`open`, `high`, `low`, `close`, `volume`). You can access prices via helpers like `data.close("SPY")`, or grab the full bar with `data.bar("SPY")` for direct attribute access. `PortfolioView` gives read-only access to current equity, cash, positions, and weights.
 
@@ -60,7 +62,7 @@ class BuyAndRebalance(Strategy):
 | `Hold()` | Keep the current allocation unchanged. |
 | `Liquidate()` | Sell all positions and move fully to cash. |
 
-## Example — SMA crossover
+## Example - SMA crossover
 
 ```python
 from hqg_algorithms import (
@@ -73,15 +75,12 @@ from collections import deque
 class SimpleSMA(Strategy):
     """Go risk-on when SPY is above its 21-day mean, otherwise hold bonds."""
 
+    universe = ["SPY", "BND"]
+    cadence = Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_CLOSE)
+
     def __init__(self):
         self._window = 21
         self._q: deque[float] = deque(maxlen=self._window)
-
-    def universe(self) -> list[str]:
-        return ["SPY", "BND"]
-
-    def cadence(self) -> Cadence:
-        return Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
 
     def on_data(self, data: Slice, portfolio: PortfolioView) -> Signal:
         spy_close = data.close("SPY")

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install hqg-algorithms
 
 Subclass `Strategy` and implement three methods:
 ```python
-from hqg_algorithms import Strategy, Cadence, Slice, PortfolioView, BarSize, CallPhase
+from hqg_algorithms import Strategy, Cadence, Slice, PortfolioView, BarSize, ExecutionTiming
 
 
 class BuyAndRebalance(Strategy):
@@ -20,7 +20,7 @@ class BuyAndRebalance(Strategy):
         return ["SPY", "IEF"]
 
     def cadence(self) -> Cadence:
-        return Cadence(bar_size=BarSize.DAILY, call_phase=CallPhase.ON_BAR_CLOSE)
+        return Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_CLOSE)
 
     def on_data(self, data: Slice, portfolio: PortfolioView) -> dict[str, float] | None:
         return {"SPY": 0.6, "IEF": 0.4}
@@ -29,14 +29,26 @@ class BuyAndRebalance(Strategy):
 | Method | Purpose |
 |--------|---------|
 | `universe()` | Symbols the platform loads for this strategy |
-| `cadence()` | Bar resolution, trigger timing, and execution delay |
+| `cadence()` | Bar resolution and execution timing |
 | `on_data()` | Return target portfolio weights, `{}` for all cash, or `None` to skip an update |
 
 `Slice` maps each symbol to a `Bar` dataclass with typed fields (`open`, `high`, `low`, `close`, `volume`). You can access prices via helpers like `data.close("SPY")`, or grab the full bar with `data.bar("SPY")` for direct attribute access. `PortfolioView` gives read-only access to current equity, cash, positions, and weights.
 
+### Execution timing
+
+`ExecutionTiming` controls when your strategy receives data and when the resulting trades fill. Pick the option that matches your signal logic:
+
+| `ExecutionTiming` | `on_data` fires at | Trades fill at |
+|---|---|---|---|
+| `CLOSE_TO_NEXT_OPEN` | Bar close | Next bar's open |
+| `CLOSE_TO_CLOSE` | Bar close | Same bar's close (DEFAULT) |
+| `OPEN_TO_OPEN` | Bar open | Same bar's open |
+
+`CLOSE_TO_NEXT_OPEN` is the most realistic for intradaily strategies since it avoids look-ahead bias - your signal only uses data that was already available before the trade executes. The other two modes assume you can observe a price and trade at that same price.
+
 ## Example — SMA crossover
 ```python
-from hqg_algorithms import Strategy, Cadence, Slice, PortfolioView, BarSize, CallPhase
+from hqg_algorithms import Strategy, Cadence, Slice, PortfolioView, BarSize, ExecutionTiming
 from collections import deque
 
 
@@ -51,7 +63,7 @@ class SimpleSMA(Strategy):
         return ["SPY", "BND"]
 
     def cadence(self) -> Cadence:
-        return Cadence(bar_size=BarSize.DAILY, call_phase=CallPhase.ON_BAR_CLOSE)
+        return Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
 
     def on_data(self, data: Slice, portfolio: PortfolioView) -> dict[str, float] | None:
         spy_close = data.close("SPY")

--- a/README.md
+++ b/README.md
@@ -12,18 +12,20 @@ pip install hqg-algorithms
 
 Subclass `Strategy` and implement three methods:
 ```python
-from hqg_algorithms import Strategy, Cadence, Slice, PortfolioView, BarSize, ExecutionTiming
-
+from hqg_algorithms import (
+    Strategy, Cadence, Slice, PortfolioView,
+    BarSize, ExecutionTiming, Signal, TargetWeights,
+)
 
 class BuyAndRebalance(Strategy):
     def universe(self) -> list[str]:
         return ["SPY", "IEF"]
 
     def cadence(self) -> Cadence:
-        return Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_CLOSE)
+        return Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
 
-    def on_data(self, data: Slice, portfolio: PortfolioView) -> dict[str, float] | None:
-        return {"SPY": 0.6, "IEF": 0.4}
+    def on_data(self, data: Slice, portfolio: PortfolioView) -> Signal:
+        return TargetWeights({"SPY": 0.6, "IEF": 0.4})
 ```
 
 | Method | Purpose |
@@ -46,9 +48,23 @@ class BuyAndRebalance(Strategy):
 
 `CLOSE_TO_NEXT_OPEN` is the most realistic for intradaily strategies since it avoids look-ahead bias - your signal only uses data that was already available before the trade executes. The other two modes assume you can observe a price and trade at that same price.
 
+### Signal types
+
+`on_data()` returns a `Signal` that tells the backtester what to do:
+
+| Signal | Meaning |
+| -------- | --------- |
+| `TargetWeights({"SPY": 0.6, "IEF": 0.4})` | Rebalance to these weights. Omitted symbols are sold to zero. Weights summing to less than 1.0 leave the remainder in cash. |
+| `Hold()` | Keep the current allocation unchanged. |
+| `Liquidate()` | Sell all positions and move fully to cash. |
+
+
 ## Example — SMA crossover
 ```python
-from hqg_algorithms import Strategy, Cadence, Slice, PortfolioView, BarSize, ExecutionTiming
+from hqg_algorithms import (
+    Strategy, Cadence, Slice, PortfolioView,
+    BarSize, ExecutionTiming, Signal, TargetWeights, Hold,
+)
 from collections import deque
 
 
@@ -65,21 +81,21 @@ class SimpleSMA(Strategy):
     def cadence(self) -> Cadence:
         return Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
 
-    def on_data(self, data: Slice, portfolio: PortfolioView) -> dict[str, float] | None:
+    def on_data(self, data: Slice, portfolio: PortfolioView) -> Signal:
         spy_close = data.close("SPY")
         if spy_close is None:
-            return None
+            return Hold()
 
         self._q.append(spy_close)
 
         if len(self._q) < self._window:
-            return {"BND": 1.0}  # hold bonds while warming up
+            return TargetWeights({"BND": 1.0})  # hold bonds while warming up
 
         sma = sum(self._q) / len(self._q)
 
         if spy_close > sma:
-            return {"SPY": 0.5, "BND": 0.5}  # uptrend
-        return {"BND": 1.0}                  # downtrend
+            return TargetWeights({"SPY": 0.5, "BND": 0.5})  # uptrend
+        return TargetWeights({"BND": 1.0})                   # downtrend
 ```
 
 ## Additional docs

--- a/hqg_algorithms/__init__.py
+++ b/hqg_algorithms/__init__.py
@@ -4,10 +4,11 @@ from .types import (
     Cadence, Slice, Bar, PortfolioView, BarSize, ExecutionTiming,
     Signal, TargetWeights, Hold, Liquidate,
 )
-from .validate import validate_strategy
+from .parsing import validate_strategy, get_strategy_metadata, StrategyMetadata
 
 __all__ = [
     "Strategy", "Cadence", "Slice", "Bar", "PortfolioView",
     "BarSize", "ExecutionTiming",
-    "Signal", "TargetWeights", "Hold", "Liquidate", "validate_strategy"
+    "Signal", "TargetWeights", "Hold", "Liquidate",
+    "validate_strategy", "get_strategy_metadata", "StrategyMetadata",
 ]

--- a/hqg_algorithms/__init__.py
+++ b/hqg_algorithms/__init__.py
@@ -1,5 +1,5 @@
 """__init__.py"""
 from .strategy import Strategy
-from .types import Cadence, Slice, PortfolioView, BarSize, CallPhase
+from .types import Cadence, Slice, Bar, PortfolioView, BarSize, CallPhase
 
-__all__ = ["Strategy", "Cadence", "Slice", "PortfolioView", "BarSize", "CallPhase"]
+__all__ = ["Strategy", "Cadence", "Slice", "Bar", "PortfolioView", "BarSize", "CallPhase"]

--- a/hqg_algorithms/__init__.py
+++ b/hqg_algorithms/__init__.py
@@ -1,5 +1,12 @@
 """__init__.py"""
 from .strategy import Strategy
-from .types import Cadence, Slice, Bar, PortfolioView, BarSize, ExecutionTiming
+from .types import (
+    Cadence, Slice, Bar, PortfolioView, BarSize, ExecutionTiming,
+    Signal, TargetWeights, Hold, Liquidate,
+)
 
-__all__ = ["Strategy", "Cadence", "Slice", "Bar", "PortfolioView", "BarSize", "ExecutionTiming"]
+__all__ = [
+    "Strategy", "Cadence", "Slice", "Bar", "PortfolioView",
+    "BarSize", "ExecutionTiming",
+    "Signal", "TargetWeights", "Hold", "Liquidate",
+]

--- a/hqg_algorithms/__init__.py
+++ b/hqg_algorithms/__init__.py
@@ -4,9 +4,10 @@ from .types import (
     Cadence, Slice, Bar, PortfolioView, BarSize, ExecutionTiming,
     Signal, TargetWeights, Hold, Liquidate,
 )
+from .validate import validate_strategy
 
 __all__ = [
     "Strategy", "Cadence", "Slice", "Bar", "PortfolioView",
     "BarSize", "ExecutionTiming",
-    "Signal", "TargetWeights", "Hold", "Liquidate",
+    "Signal", "TargetWeights", "Hold", "Liquidate", "validate_strategy"
 ]

--- a/hqg_algorithms/__init__.py
+++ b/hqg_algorithms/__init__.py
@@ -1,5 +1,5 @@
 """__init__.py"""
 from .strategy import Strategy
-from .types import Cadence, Slice, Bar, PortfolioView, BarSize, CallPhase
+from .types import Cadence, Slice, Bar, PortfolioView, BarSize, ExecutionTiming
 
-__all__ = ["Strategy", "Cadence", "Slice", "Bar", "PortfolioView", "BarSize", "CallPhase"]
+__all__ = ["Strategy", "Cadence", "Slice", "Bar", "PortfolioView", "BarSize", "ExecutionTiming"]

--- a/hqg_algorithms/parsing.py
+++ b/hqg_algorithms/parsing.py
@@ -1,14 +1,28 @@
 """validate.py"""
 import ast
+from dataclasses import dataclass
 from typing import Optional
 
-from hqg_algorithms.types import BarSize, ExecutionTiming
+from hqg_algorithms.types import BarSize, ExecutionTiming, Cadence
+
 
 VALID_BAR_SIZES = {e.name for e in BarSize}
 VALID_EXECUTIONS = {e.name for e in ExecutionTiming}
 VALID_CADENCE_KWARGS = {"bar_size", "execution"}
+BARSIZE_MAP = {e.name: e for e in BarSize}
+EXECUTION_MAP = {e.name: e for e in ExecutionTiming}
+
+MAX_TICKER_LEN = 12
+MAX_UNIVERSE_SIZE = 200
 
 
+@dataclass(frozen=True)
+class StrategyMetadata:
+    universe: list[str]
+    cadence: Cadence
+
+
+# public
 def validate_strategy(source: str) -> list[str]:
     """
     Validate strategy source code without executing it.
@@ -48,7 +62,30 @@ def validate_strategy(source: str) -> list[str]:
 
     return errors
 
+# public
+def get_strategy_metadata(source: str) -> StrategyMetadata:
+    """
+    Parse strategy source code and extract universe + cadence.
+    No code is executed. Raises ValueError if source is invalid.
+    """
+    errors = validate_strategy(source)
+    if errors:
+        raise ValueError("Invalid strategy:\n" + "\n".join(f"  - {e}" for e in errors))
 
+    tree = ast.parse(source)
+    cls = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef) and _is_strategy_subclass(node)
+    )
+
+    universe = _extract_universe(cls)
+    cadence = _extract_cadence(cls)
+
+    return StrategyMetadata(universe=universe, cadence=cadence)
+
+
+
+### parsing helpers
 def _is_strategy_subclass(node: ast.ClassDef) -> bool:
     """Check if a class inherits from Strategy (handles `Strategy` and `mod.Strategy`)."""
     return any(
@@ -72,9 +109,7 @@ def _get_class_assign(cls: ast.ClassDef, name: str) -> Optional[ast.expr]:
     return None
 
 
-MAX_TICKER_LEN = 12
-MAX_UNIVERSE_SIZE = 200
-
+### Validation checks
 def _check_universe(cls: ast.ClassDef) -> Optional[list[str]]:
     """Returns None if no universe found, [] if valid, [errors] if invalid."""
     value = _get_class_assign(cls, "universe")
@@ -117,7 +152,7 @@ def _check_universe(cls: ast.ClassDef) -> Optional[list[str]]:
         errors.append("'universe' has no valid tickers after cleaning")
 
     if valid_count > MAX_UNIVERSE_SIZE:
-        errors.append(f"universe has {valid_count} distinct tickers (max {MAX_UNIVERSE_SIZE})")
+        errors.append(f"universe has {valid_count} valid tickers (max {MAX_UNIVERSE_SIZE})")
 
     return errors
 
@@ -164,3 +199,39 @@ def _check_on_data(cls: ast.ClassDef) -> Optional[list[str]]:
         if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == "on_data":
             return []
     return ["Missing 'on_data' method"]
+
+
+### Extraction (post-validation)
+def _extract_universe(cls: ast.ClassDef) -> list[str]:
+    """Extract and clean universe. Only called after validation passes."""
+    value = _get_class_assign(cls, "universe")
+    raw = ast.literal_eval(value)
+
+    seen = set()
+    cleaned = []
+    for item in raw:
+        ticker = item.strip().upper()
+        if ticker and ticker not in seen:
+            seen.add(ticker)
+            cleaned.append(ticker)
+
+    return cleaned
+
+
+def _extract_cadence(cls: ast.ClassDef) -> Cadence:
+    """Extract cadence. Only called after validation passes."""
+    value = _get_class_assign(cls, "cadence")
+    if value is None:
+        return Cadence()
+
+    bar_size = BarSize.DAILY
+    execution = ExecutionTiming.CLOSE_TO_CLOSE
+
+    for kw in value.keywords:
+        attr = kw.value.attr
+        if kw.arg == "bar_size":
+            bar_size = BARSIZE_MAP[attr]
+        elif kw.arg == "execution":
+            execution = EXECUTION_MAP[attr]
+
+    return Cadence(bar_size=bar_size, execution=execution)

--- a/hqg_algorithms/strategy.py
+++ b/hqg_algorithms/strategy.py
@@ -1,6 +1,6 @@
 """strategy.py"""
 from abc import ABC, abstractmethod
-from hqg_algorithms.types import Cadence, Slice, PortfolioView
+from hqg_algorithms.types import Cadence, Slice, PortfolioView, Signal
 
 class Strategy(ABC):
     """
@@ -9,7 +9,7 @@ class Strategy(ABC):
     Each subclass defines:
       - The asset universe it trades.
       - The cadence (how often it's called and when trades execute).
-      - The trading logic that converts data into target portfolio weights.
+      - The trading logic that converts data into a Signal.
 
     The backtester calls:
       1. strategy.universe() to know what tickers to load.
@@ -43,7 +43,7 @@ class Strategy(ABC):
         """
 
     @abstractmethod
-    def on_data(self, data: Slice, portfolio: PortfolioView) -> dict[str, float] | None:
+    def on_data(self, data: Slice, portfolio: PortfolioView) -> Signal:
         """
         Main signal logic.
 
@@ -54,15 +54,15 @@ class Strategy(ABC):
             portfolio: a read-only PortfolioView with current equity, cash, positions,
                 and weights.
 
-        Returns:
-            dict[str, float]: target portfolio weights, e.g. {"SPY": 0.6, "IEF": 0.4}
-            or None to indicate no change to previous allocation.
-
-        - The returned dictionary expresses the complete target allocation.
-        - If a symbol is omitted, we sell it down to zero.
-        - Sum of weights less than 1 implies remaining balance held as cash.
-        - {} means we should convert our portfolio to fully cash.
-        - None means skip rebalance (no signal update this bar).
+        Returns one of:
+            TargetWeights({"SPY": 0.6, "IEF": 0.4})
+                - Set the portfolio to these target weights. 
+                - Omitted symbols are sold to zero.
+                - Weights summing to less than 1.0 leave the remainder in cash.
+            Hold()
+                Keep the current allocation unchanged (skip this bar).
+            Liquidate()
+                Sell everything and move fully to cash.
 
         Called automatically according to cadence().
         """

--- a/hqg_algorithms/strategy.py
+++ b/hqg_algorithms/strategy.py
@@ -14,7 +14,7 @@ class Strategy(ABC):
     The backtester calls:
       1. strategy.universe() to know what tickers to load.
       2. strategy.cadence() to schedule on_data calls.
-      3. strategy.on_data(t, slice_) each time new data arrives.
+      3. strategy.on_data(data, portfolio) each time new data arrives.
     """
 
     def __init__(self) -> None:
@@ -34,8 +34,8 @@ class Strategy(ABC):
     @abstractmethod
     def cadence(self) -> Cadence:
         """
-        Return a Cadence object or similar structure describing:
-          - bar_size (e.g., 1 day, 5 minutes)
+        Return a Cadence object describing:
+          - bar_size (e.g., 1 day, 1 week)
           - call_phase ("on_bar_close" or "on_bar_open")
           - exec_lag_bars (how many bars later to execute trades)
 
@@ -48,17 +48,20 @@ class Strategy(ABC):
         Main signal logic.
 
         Args:
-            data: a "slice" of the current bar's data, typically a dict:
-                  { "SPY": {"open":..., "high":..., "low":..., "close":...}, ... }
+            data: a Slice mapping each symbol to a Bar dataclass with typed OHLCV fields. 
+                Access prices via helpers like data.close("SPY") or grab the full bar with
+                data.bar("SPY") for direct attribute access (e.g. bar.open, bar.high, ...).
+            portfolio: a read-only PortfolioView with current equity, cash, positions,
+                and weights.
 
         Returns:
             dict[str, float]: target portfolio weights, e.g. {"SPY": 0.6, "IEF": 0.4}
-            or None to indicate no change to previous allocation
+            or None to indicate no change to previous allocation.
 
         - The returned dictionary expresses the complete target allocation.
         - If a symbol is omitted, we sell it down to zero.
         - Sum of weights less than 1 implies remaining balance held as cash.
-        - {} means we should covert our portfolio to fully cash.
+        - {} means we should convert our portfolio to fully cash.
         - None means skip rebalance (no signal update this bar).
 
         Called automatically according to cadence().

--- a/hqg_algorithms/strategy.py
+++ b/hqg_algorithms/strategy.py
@@ -1,5 +1,6 @@
 """strategy.py"""
 from abc import ABC, abstractmethod
+from typing import Callable
 from hqg_algorithms.types import Cadence, Slice, PortfolioView, Signal
 
 class Strategy(ABC):
@@ -36,6 +37,8 @@ class Strategy(ABC):
     cadence: Cadence = Cadence()
     """How often on_data is called and when trades fill. Defaults to daily, close-to-close."""
 
+    _log_handler: Callable[[str], None] = staticmethod(print)
+
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         if not hasattr(cls, 'universe') or not isinstance(cls.universe, list) or len(cls.universe) == 0:
@@ -43,6 +46,11 @@ class Strategy(ABC):
                 f"{cls.__name__} must define 'universe' as a non-empty list of tickers. "
                 f'e.g. universe = ["SPY", "IEF"]'
             )
+    
+
+    def log(self, message: str) -> None:
+        self._log_handler(message)
+
 
     @abstractmethod
     def on_data(self, data: Slice, portfolio: PortfolioView) -> Signal:

--- a/hqg_algorithms/strategy.py
+++ b/hqg_algorithms/strategy.py
@@ -59,6 +59,7 @@ class Strategy(ABC):
                 - Set the portfolio to these target weights. 
                 - Omitted symbols are sold to zero.
                 - Weights summing to less than 1.0 leave the remainder in cash.
+                - ValueError: If any weight is negative or weights sum above 1.0.
             Hold()
                 Keep the current allocation unchanged (skip this bar).
             Liquidate()

--- a/hqg_algorithms/strategy.py
+++ b/hqg_algorithms/strategy.py
@@ -7,40 +7,42 @@ class Strategy(ABC):
     Base interface for all trading strategies.
 
     Each subclass defines:
-      - The asset universe it trades.
-      - The cadence (how often it's called and when trades execute).
-      - The trading logic that converts data into a Signal.
+      - The asset universe it trades (class variable).
+      - The cadence: how often it's called and when trades execute (class variable).
+      - The trading logic that converts data into a Signal (on_data method).
 
-    The backtester calls:
-      1. strategy.universe() to know what tickers to load.
-      2. strategy.cadence() to schedule on_data calls.
-      3. strategy.on_data(data, portfolio) each time new data arrives.
+    Usage:
+        from hqg_algorithms import Strategy, Cadence, BarSize, ExecutionTiming
+
+        class MyStrategy(Strategy):
+            universe = ["SPY", "IEF", "GLD"]
+            cadence = Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
+
+            def on_data(self, data, portfolio):
+                ...
+
+    Notes:
+        - universe must be a list literal of ticker strings.
+        - cadence must be a direct Cadence(...) call with BarSize.X and/or
+          ExecutionTiming.Y keyword arguments. Defaults to daily bars with
+          close-to-close execution if omitted.
+        - These are parsed via AST (not executed) on the host for data loading,
+          so these definitions cannot use variables, function calls, or aliased imports.
     """
 
-    def __init__(self) -> None:
-        """Initialize internal state for the strategy (if any)."""
+    universe: list[str]
+    """List of tickers this strategy trades. e.g. ["SPY", "IEF", "GLD"]"""
 
-    @abstractmethod
-    def universe(self) -> list[str]:
-        """
-        Return a list of tickers or instruments this strategy trades.
+    cadence: Cadence = Cadence()
+    """How often on_data is called and when trades fill. Defaults to daily, close-to-close."""
 
-        Example:
-            return ["SPY", "IEF", "GLD"]
-
-        Used by the backtester to determine what data to load.
-        """
-
-    @abstractmethod
-    def cadence(self) -> Cadence:
-        """
-        Return a Cadence object describing:
-          - bar_size (e.g., daily, weekly)
-          - execution (when on_data fires and when trades fill, e.g.
-            CLOSE_TO_NEXT_OPEN, CLOSE_TO_CLOSE, or OPEN_TO_OPEN)
-
-        This tells the executor when to call on_data and when to fill orders.
-        """
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if not hasattr(cls, 'universe') or not isinstance(cls.universe, list) or len(cls.universe) == 0:
+            raise TypeError(
+                f"{cls.__name__} must define 'universe' as a non-empty list of tickers. "
+                f'e.g. universe = ["SPY", "IEF"]'
+            )
 
     @abstractmethod
     def on_data(self, data: Slice, portfolio: PortfolioView) -> Signal:
@@ -48,7 +50,7 @@ class Strategy(ABC):
         Main signal logic.
 
         Args:
-            data: a Slice mapping each symbol to a Bar dataclass with typed OHLCV fields. 
+            data: a Slice mapping each symbol to a Bar dataclass with typed OHLCV fields.
                 Access prices via helpers like data.close("SPY") or grab the full bar with
                 data.bar("SPY") for direct attribute access (e.g. bar.open, bar.high, ...).
             portfolio: a read-only PortfolioView with current equity, cash, positions,
@@ -56,7 +58,7 @@ class Strategy(ABC):
 
         Returns one of:
             TargetWeights({"SPY": 0.6, "IEF": 0.4})
-                - Set the portfolio to these target weights. 
+                - Set the portfolio to these target weights.
                 - Omitted symbols are sold to zero.
                 - Weights summing to less than 1.0 leave the remainder in cash.
                 - ValueError: If any weight is negative or weights sum above 1.0.
@@ -65,5 +67,5 @@ class Strategy(ABC):
             Liquidate()
                 Sell everything and move fully to cash.
 
-        Called automatically according to cadence().
+        Called automatically according to cadence.
         """

--- a/hqg_algorithms/strategy.py
+++ b/hqg_algorithms/strategy.py
@@ -35,9 +35,9 @@ class Strategy(ABC):
     def cadence(self) -> Cadence:
         """
         Return a Cadence object describing:
-          - bar_size (e.g., 1 day, 1 week)
-          - call_phase ("on_bar_close" or "on_bar_open")
-          - exec_lag_bars (how many bars later to execute trades)
+          - bar_size (e.g., daily, weekly)
+          - execution (when on_data fires and when trades fill, e.g.
+            CLOSE_TO_NEXT_OPEN, CLOSE_TO_CLOSE, or OPEN_TO_OPEN)
 
         This tells the executor when to call on_data and when to fill orders.
         """

--- a/hqg_algorithms/types.py
+++ b/hqg_algorithms/types.py
@@ -31,7 +31,7 @@ class Bar:
     high: float
     low: float
     close: float
-    volume: float
+    volume: Optional[float]     # not available for all data
 
 
 class Slice(Mapping[str, Bar]):
@@ -100,17 +100,14 @@ class Slice(Mapping[str, Bar]):
 @dataclass(frozen=True)
 class PortfolioView:
     """Read-only snapshot of the strategy's current portfolio state."""
-    equity: float                 # total value of the strategy's portfolio
-    cash: float                   # available, unallocated cash
-    positions: dict[str, float]   # quantity of each symbol
-    weights: dict[str, float]     # current portfolio weights (by value)
+    equity: float                    # total value of the strategy's portfolio
+    cash: float                      # available, unallocated cash
+    positions: Mapping[str, float]   # quantity of each symbol
+    weights: Mapping[str, float]     # current portfolio weights (by value)
 
-    def __init__(self, equity: float, cash: float,
-                 positions: dict[str, float], weights: dict[str, float]):
-        object.__setattr__(self, 'equity', equity)
-        object.__setattr__(self, 'cash', cash)
-        object.__setattr__(self, 'positions', MappingProxyType(dict(positions)))
-        object.__setattr__(self, 'weights', MappingProxyType(dict(weights)))
+    def __post_init__(self) -> None:
+        object.__setattr__(self, 'positions', MappingProxyType(dict(self.positions)))
+        object.__setattr__(self, 'weights', MappingProxyType(dict(self.weights)))
 
 class Signal:
     """Base class for all strategy signals returned by on_data()."""
@@ -140,7 +137,8 @@ class TargetWeights(Signal):
                 f"Weights sum to {total:.6f}, which exceeds 1.0. "
                 "Use weights that sum to at most 1.0 (remainder is held as cash)."
             )
-         # freeze after validation
+        
+        # freeze after validation
         object.__setattr__(self, 'weights', MappingProxyType(dict(self.weights)))
 
 class Hold(Signal):

--- a/hqg_algorithms/types.py
+++ b/hqg_algorithms/types.py
@@ -22,17 +22,24 @@ class Cadence:
     call_phase: CallPhase = CallPhase.ON_BAR_CLOSE # when on_data fires within each bar
     exec_lag_bars: int = 0                         # bars between signal and execution
 
+@dataclass(frozen=True)
+class Bar:
+    """OHLCV data for a single symbol at one timestep."""
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
 
-class Slice(dict[str, dict[str, float]]):
+
+class Slice(dict[str, Bar]):
     """
     Snapshot of OHLCV data for all symbols at one timestep.
 
     Structure:
         {
-            "SPY": {"open": 444.2, "high": 445.0, "low": 443.9,
-                    "close": 444.5, "volume": 1.2e7},
-            "IEF": {"open": 97.1,  "high": 97.5,  "low": 97.0,
-                    "close": 97.4,  "volume": 4.1e6},
+            "SPY": Bar(open=444.2, high=445.0, low=443.9, close=444.5, volume=1.2e7),
+            "IEF": Bar(open=97.1,  high=97.5,  low=97.0, close=97.4,  volume=4.1e6),
         }
     """
 
@@ -44,29 +51,36 @@ class Slice(dict[str, dict[str, float]]):
         """Check whether this slice includes a given symbol."""
         return symbol in self
 
-    def _get_field(self, symbol: str, field: str) -> Optional[float]:
-        """Return a specific OHLCV field for a symbol, or None if missing."""
-        return self.get(symbol, {}).get(field)
+    def bar(self, symbol: str) -> Optional[Bar]:
+        """Return the full Bar for a symbol, or None if missing."""
+        return self.get(symbol)
 
     def open(self, symbol: str) -> Optional[float]:
         """Return the open price for a symbol, or None if missing."""
-        return self._get_field(symbol, "open")
+        b = self.get(symbol)
+        return b.open if b is not None else None
 
     def high(self, symbol: str) -> Optional[float]:
         """Return the high price for a symbol, or None if missing."""
-        return self._get_field(symbol, "high")
+        b = self.get(symbol)
+        return b.high if b is not None else None
 
     def low(self, symbol: str) -> Optional[float]:
         """Return the low price for a symbol, or None if missing."""
-        return self._get_field(symbol, "low")
+        b = self.get(symbol)
+        return b.low if b is not None else None
 
     def close(self, symbol: str) -> Optional[float]:
         """Return the close price for a symbol, or None if missing."""
-        return self._get_field(symbol, "close")
+        b = self.get(symbol)
+        return b.close if b is not None else None
 
     def volume(self, symbol: str) -> Optional[float]:
         """Return the volume for a symbol, or None if missing."""
-        return self._get_field(symbol, "volume")
+        b = self.get(symbol)
+        return b.volume if b is not None else None
+
+
 @dataclass(frozen=True)
 class PortfolioView:
     """Read-only snapshot of the strategy's current portfolio state."""

--- a/hqg_algorithms/types.py
+++ b/hqg_algorithms/types.py
@@ -10,17 +10,17 @@ class BarSize(str, Enum):
     MONTHLY = "1m"
     QUARTERLY = "1q"
 
-class CallPhase(str, Enum):
-    ON_BAR_CLOSE = "on_bar_close"
-    ON_BAR_OPEN = "on_bar_open"
+class ExecutionTiming(str, Enum):
+    CLOSE_TO_CLOSE = "close_to_close"           # signal on close, fill same close
+    CLOSE_TO_NEXT_OPEN = "close_to_next_open"   # signal on close, fill next open
+    OPEN_TO_OPEN = "open_to_open"               # signal on open, fill same open
 
 
 @dataclass(frozen=True)
 class Cadence:
     """Defines how often a strategy runs and when trades execute."""
-    bar_size: BarSize = BarSize.DAILY              # bar resolution (1d, 1w, 1m, 1q)
-    call_phase: CallPhase = CallPhase.ON_BAR_CLOSE # when on_data fires within each bar
-    exec_lag_bars: int = 0                         # bars between signal and execution
+    bar_size: BarSize = BarSize.DAILY                               # bar resolution (1d, 1w, 1m, 1q)
+    execution: ExecutionTiming = ExecutionTiming.CLOSE_TO_CLOSE     # signal on close, fill same close
 
 @dataclass(frozen=True)
 class Bar:

--- a/hqg_algorithms/types.py
+++ b/hqg_algorithms/types.py
@@ -1,7 +1,7 @@
 """types.py"""
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Mapping, Optional
 
 
 class BarSize(str, Enum):
@@ -88,3 +88,29 @@ class PortfolioView:
     cash: float                   # available, unallocated cash
     positions: dict[str, float]   # quantity of each symbol
     weights: dict[str, float]     # current portfolio weights (by value)
+
+class Signal:
+    """Base class for all strategy signals returned by on_data()."""
+
+@dataclass(frozen=True)
+class TargetWeights(Signal):
+    """
+    Set the portfolio to the given target weights.
+
+    - Symbols present in `weights` are sized to the specified fraction of portfolio equity. 
+    - Symbols absent from `weights` are sold to zero.
+    - Weights summing to less than 1.0 leave the remainder in cash.
+    """
+    weights: Mapping[str, float]
+
+
+class Hold(Signal):
+    """
+    Keep the current portfolio unchanged this bar.
+    """
+
+
+class Liquidate(Signal):
+    """
+    Sell all positions and move fully to cash.
+    """

--- a/hqg_algorithms/types.py
+++ b/hqg_algorithms/types.py
@@ -33,7 +33,7 @@ class Bar:
     volume: float
 
 
-class Slice(dict[str, Bar]):
+class Slice(Mapping[str, Bar]):
     """
     Snapshot of OHLCV data for all symbols at one timestep.
 
@@ -44,43 +44,57 @@ class Slice(dict[str, Bar]):
         }
     """
 
+    def __init__(self, data: dict[str, Bar]):
+        self._data = dict(data)
+
+    def __getitem__(self, key: str) -> Bar:
+        return self._data[key]
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __repr__(self) -> str:
+        return f"Slice({self._data!r})"
+
     def symbols(self) -> list[str]:
         """Return list of all symbols in this slice."""
-        return list(self.keys())
+        return list(self._data.keys())
 
     def has(self, symbol: str) -> bool:
         """Check whether this slice includes a given symbol."""
-        return symbol in self
+        return symbol in self._data
 
     def bar(self, symbol: str) -> Optional[Bar]:
         """Return the full Bar for a symbol, or None if missing."""
-        return self.get(symbol)
+        return self._data.get(symbol)
 
     def open(self, symbol: str) -> Optional[float]:
         """Return the open price for a symbol, or None if missing."""
-        b = self.get(symbol)
+        b = self._data.get(symbol)
         return b.open if b is not None else None
 
     def high(self, symbol: str) -> Optional[float]:
         """Return the high price for a symbol, or None if missing."""
-        b = self.get(symbol)
+        b = self._data.get(symbol)
         return b.high if b is not None else None
 
     def low(self, symbol: str) -> Optional[float]:
         """Return the low price for a symbol, or None if missing."""
-        b = self.get(symbol)
+        b = self._data.get(symbol)
         return b.low if b is not None else None
 
     def close(self, symbol: str) -> Optional[float]:
         """Return the close price for a symbol, or None if missing."""
-        b = self.get(symbol)
+        b = self._data.get(symbol)
         return b.close if b is not None else None
 
     def volume(self, symbol: str) -> Optional[float]:
         """Return the volume for a symbol, or None if missing."""
-        b = self.get(symbol)
+        b = self._data.get(symbol)
         return b.volume if b is not None else None
-
 
 @dataclass(frozen=True)
 class PortfolioView:

--- a/hqg_algorithms/types.py
+++ b/hqg_algorithms/types.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import Mapping, Optional
+from types import MappingProxyType
 
 
 class BarSize(str, Enum):
@@ -104,6 +105,12 @@ class PortfolioView:
     positions: dict[str, float]   # quantity of each symbol
     weights: dict[str, float]     # current portfolio weights (by value)
 
+    def __init__(self, equity: float, cash: float,
+                 positions: dict[str, float], weights: dict[str, float]):
+        object.__setattr__(self, 'equity', equity)
+        object.__setattr__(self, 'cash', cash)
+        object.__setattr__(self, 'positions', MappingProxyType(dict(positions)))
+        object.__setattr__(self, 'weights', MappingProxyType(dict(weights)))
 
 class Signal:
     """Base class for all strategy signals returned by on_data()."""
@@ -133,6 +140,8 @@ class TargetWeights(Signal):
                 f"Weights sum to {total:.6f}, which exceeds 1.0. "
                 "Use weights that sum to at most 1.0 (remainder is held as cash)."
             )
+         # freeze after validation
+        object.__setattr__(self, 'weights', MappingProxyType(dict(self.weights)))
 
 class Hold(Signal):
     """

--- a/hqg_algorithms/types.py
+++ b/hqg_algorithms/types.py
@@ -22,6 +22,7 @@ class Cadence:
     bar_size: BarSize = BarSize.DAILY                               # bar resolution (1d, 1w, 1m, 1q)
     execution: ExecutionTiming = ExecutionTiming.CLOSE_TO_CLOSE     # signal on close, fill same close
 
+
 @dataclass(frozen=True)
 class Bar:
     """OHLCV data for a single symbol at one timestep."""
@@ -89,6 +90,7 @@ class PortfolioView:
     positions: dict[str, float]   # quantity of each symbol
     weights: dict[str, float]     # current portfolio weights (by value)
 
+
 class Signal:
     """Base class for all strategy signals returned by on_data()."""
 
@@ -100,15 +102,28 @@ class TargetWeights(Signal):
     - Symbols present in `weights` are sized to the specified fraction of portfolio equity. 
     - Symbols absent from `weights` are sold to zero.
     - Weights summing to less than 1.0 leave the remainder in cash.
+    
+    Raises:
+        ValueError: If any weight is negative or weights sum above 1.0.
+        Bad input are likely a logic/math ERROR, not something we should try to clamp or normalize. 
     """
     weights: Mapping[str, float]
 
+    def __post_init__(self) -> None:
+        negative = {s: w for s, w in self.weights.items() if w < 0}
+        if negative:
+            raise ValueError(f"Negative weights are not allowed: {negative}")
+        total = sum(self.weights.values())
+        if total > 1.0 + 1e-7:
+            raise ValueError(
+                f"Weights sum to {total:.6f}, which exceeds 1.0. "
+                "Use weights that sum to at most 1.0 (remainder is held as cash)."
+            )
 
 class Hold(Signal):
     """
     Keep the current portfolio unchanged this bar.
     """
-
 
 class Liquidate(Signal):
     """

--- a/hqg_algorithms/types.py
+++ b/hqg_algorithms/types.py
@@ -14,7 +14,6 @@ class BarSize(str, Enum):
 class ExecutionTiming(str, Enum):
     CLOSE_TO_CLOSE = "close_to_close"           # DEFAULT: signal on close, fill same close
     CLOSE_TO_NEXT_OPEN = "close_to_next_open"   # signal on close, fill next open
-    OPEN_TO_OPEN = "open_to_open"               # signal on open, fill same open
 
 
 @dataclass(frozen=True)

--- a/hqg_algorithms/types.py
+++ b/hqg_algorithms/types.py
@@ -12,7 +12,7 @@ class BarSize(str, Enum):
     QUARTERLY = "1q"
 
 class ExecutionTiming(str, Enum):
-    CLOSE_TO_CLOSE = "close_to_close"           # signal on close, fill same close
+    CLOSE_TO_CLOSE = "close_to_close"           # DEFAULT: signal on close, fill same close
     CLOSE_TO_NEXT_OPEN = "close_to_next_open"   # signal on close, fill next open
     OPEN_TO_OPEN = "open_to_open"               # signal on open, fill same open
 

--- a/hqg_algorithms/validate.py
+++ b/hqg_algorithms/validate.py
@@ -61,8 +61,7 @@ def _check_universe(cls: ast.ClassDef) -> Optional[list[str]]:
 def _check_cadence(cls: ast.ClassDef) -> Optional[list[str]]:
     """Returns None if no cadence found (ok, uses default), [] if valid, [errors] if invalid."""
     VALID_BAR_SIZES = {"DAILY", "WEEKLY", "MONTHLY", "QUARTERLY"}
-    VALID_EXECUTIONS = {"CLOSE_TO_CLOSE", "CLOSE_TO_NEXT_OPEN", "OPEN_TO_OPEN"}
-
+    VALID_EXECUTIONS = {"CLOSE_TO_CLOSE", "CLOSE_TO_NEXT_OPEN"}
     for item in cls.body:
         if not isinstance(item, ast.Assign):
             continue

--- a/hqg_algorithms/validate.py
+++ b/hqg_algorithms/validate.py
@@ -2,94 +2,164 @@
 import ast
 from typing import Optional
 
+from hqg_algorithms.types import BarSize, ExecutionTiming
+
+VALID_BAR_SIZES = {e.name for e in BarSize}
+VALID_EXECUTIONS = {e.name for e in ExecutionTiming}
+VALID_CADENCE_KWARGS = {"bar_size", "execution"}
+
 
 def validate_strategy(source: str) -> list[str]:
     """
     Validate strategy source code without executing it.
     Returns a list of error messages. Empty list = valid.
     """
-    errors = []
-
     try:
         tree = ast.parse(source)
     except SyntaxError as e:
         return [f"Syntax error on line {e.lineno}: {e.msg}"]
 
-    # Find first class with a universe assignment
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.ClassDef):
-            continue
+    # Find strategy classes (classes that inherit from Strategy)
+    strategy_classes = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef) and _is_strategy_subclass(node)
+    ]
 
-        universe = _check_universe(node)
-        cadence = _check_cadence(node)
-        on_data = _check_on_data(node)
+    if not strategy_classes:
+        return ["No strategy class found. Define a class that inherits from Strategy with 'universe' and 'on_data'."]
 
-        if universe is not None:
-            # This looks like a strategy class
-            if universe:
-                errors.extend(universe)
-            if cadence:
-                errors.extend(cadence)
-            if on_data:
-                errors.extend(on_data)
-            return errors
+    # Validate the first Strategy subclass
+    cls = strategy_classes[0]
+    errors = []
 
-    return ["No strategy class found. Define a class with 'universe' and 'on_data'."]
+    universe_errors = _check_universe(cls)
+    if universe_errors is None:
+        errors.append(f"'{cls.name}' is missing 'universe'. Define it as a list of ticker strings, e.g. universe = [\"SPY\", \"IEF\"]")
+    elif universe_errors:
+        errors.extend(universe_errors)
 
+    cadence_errors = _check_cadence(cls)
+    if cadence_errors:
+        errors.extend(cadence_errors)
+
+    on_data_errors = _check_on_data(cls)
+    if on_data_errors:
+        errors.extend(on_data_errors)
+
+    return errors
+
+
+def _is_strategy_subclass(node: ast.ClassDef) -> bool:
+    """Check if a class inherits from Strategy (handles `Strategy` and `mod.Strategy`)."""
+    return any(
+        (isinstance(b, ast.Name) and b.id == "Strategy")
+        or (isinstance(b, ast.Attribute) and b.attr == "Strategy")
+        for b in node.bases
+    )
+
+
+def _get_class_assign(cls: ast.ClassDef, name: str) -> Optional[ast.expr]:
+    """Find value node for a class-level assignment by name. Supports Assign and AnnAssign."""
+    for item in cls.body:
+        if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name) and item.target.id == name:
+            if item.value is None:
+                return None  # annotation-only, no value
+            return item.value
+        if isinstance(item, ast.Assign):
+            for target in item.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    return item.value
+    return None
+
+
+MAX_TICKER_LEN = 12
+MAX_UNIVERSE_SIZE = 200
 
 def _check_universe(cls: ast.ClassDef) -> Optional[list[str]]:
     """Returns None if no universe found, [] if valid, [errors] if invalid."""
-    for item in cls.body:
-        if not isinstance(item, ast.Assign):
+    value = _get_class_assign(cls, "universe")
+    if value is None:
+        return None
+
+    try:
+        val = ast.literal_eval(value)
+    except (ValueError, TypeError):
+        return ["'universe' must be a list literal, e.g. [\"SPY\", \"IEF\"]"]
+
+    if not isinstance(val, list):
+        return [f"'universe' must be a list, got {type(val).__name__}"]
+
+    if len(val) == 0:
+        return ["'universe' must not be empty"]
+
+    errors = []
+    seen = set()
+    valid_count = 0
+
+    for i, item in enumerate(val):
+        if not isinstance(item, str):
+            errors.append(f"universe[{i}]: expected string, got {type(item).__name__} ({item!r})")
             continue
-        for target in item.targets:
-            if isinstance(target, ast.Name) and target.id == "universe":
-                try:
-                    val = ast.literal_eval(item.value)
-                except (ValueError, TypeError):
-                    return [f"'universe' must be a list literal, e.g. [\"SPY\", \"IEF\"]"]
-                if not isinstance(val, list):
-                    return [f"'universe' must be a list, got {type(val).__name__}"]
-                if not all(isinstance(s, str) for s in val):
-                    return ["'universe' must contain only strings"]
-                if len(val) == 0:
-                    return ["'universe' must not be empty"]
-                return []
-    return None
+
+        ticker = item.strip().upper()
+
+        if not ticker:
+            errors.append(f"universe[{i}]: empty or whitespace-only ticker")
+        elif len(ticker) > MAX_TICKER_LEN:
+            errors.append(f"universe[{i}]: '{ticker}' exceeds {MAX_TICKER_LEN} characters")
+        elif ticker in seen:
+            continue
+        else:
+            seen.add(ticker)
+            valid_count += 1
+
+    if valid_count <= 0:
+        errors.append("'universe' has no valid tickers after cleaning")
+
+    if valid_count > MAX_UNIVERSE_SIZE:
+        errors.append(f"universe has {valid_count} distinct tickers (max {MAX_UNIVERSE_SIZE})")
+
+    return errors
 
 
 def _check_cadence(cls: ast.ClassDef) -> Optional[list[str]]:
     """Returns None if no cadence found (ok, uses default), [] if valid, [errors] if invalid."""
-    VALID_BAR_SIZES = {"DAILY", "WEEKLY", "MONTHLY", "QUARTERLY"}
-    VALID_EXECUTIONS = {"CLOSE_TO_CLOSE", "CLOSE_TO_NEXT_OPEN"}
-    for item in cls.body:
-        if not isinstance(item, ast.Assign):
+    value = _get_class_assign(cls, "cadence")
+    if value is None:
+        return None
+
+    if not isinstance(value, ast.Call):
+        return ["'cadence' must be a Cadence(...) call"]
+
+    func = value.func
+    name = func.id if isinstance(func, ast.Name) else (func.attr if isinstance(func, ast.Attribute) else None)
+    if name != "Cadence":
+        return [f"'cadence' must be a Cadence(...) call, got {name}(...)"]
+
+    if value.args:
+        return ["'cadence' does not accept positional arguments, use keyword arguments: Cadence(bar_size=..., execution=...)"]
+
+    # Reject unknown kwargs
+    unknown = {kw.arg for kw in value.keywords if kw.arg is not None} - VALID_CADENCE_KWARGS
+    if unknown:
+        return [f"Unknown cadence argument(s): {', '.join(sorted(unknown))}. Valid: {', '.join(sorted(VALID_CADENCE_KWARGS))}"]
+
+    errors = []
+    for kw in value.keywords:
+        val = kw.value
+        if not (isinstance(val, ast.Attribute) and isinstance(val.value, ast.Name)):
+            errors.append(f"cadence argument '{kw.arg}' must be BarSize.X or ExecutionTiming.Y")
             continue
-        for target in item.targets:
-            if isinstance(target, ast.Name) and target.id == "cadence":
-                node = item.value
-                if not isinstance(node, ast.Call):
-                    return ["'cadence' must be a Cadence(...) call"]
+        if kw.arg == "bar_size" and val.attr not in VALID_BAR_SIZES:
+            errors.append(f"Unknown bar_size '{val.attr}'. Valid: {', '.join(sorted(VALID_BAR_SIZES))}")
+        if kw.arg == "execution" and val.attr not in VALID_EXECUTIONS:
+            errors.append(f"Unknown execution '{val.attr}'. Valid: {', '.join(sorted(VALID_EXECUTIONS))}")
 
-                func = node.func
-                name = func.id if isinstance(func, ast.Name) else (func.attr if isinstance(func, ast.Attribute) else None)
-                if name != "Cadence":
-                    return [f"'cadence' must be a Cadence(...) call, got {name}(...)"]
-
-                for kw in node.keywords:
-                    val = kw.value
-                    if not (isinstance(val, ast.Attribute) and isinstance(val.value, ast.Name)):
-                        return [f"cadence argument '{kw.arg}' must be BarSize.X or ExecutionTiming.Y"]
-                    if kw.arg == "bar_size" and val.attr not in VALID_BAR_SIZES:
-                        return [f"Unknown bar_size '{val.attr}'. Valid: {', '.join(sorted(VALID_BAR_SIZES))}"]
-                    if kw.arg == "execution" and val.attr not in VALID_EXECUTIONS:
-                        return [f"Unknown execution '{val.attr}'. Valid: {', '.join(sorted(VALID_EXECUTIONS))}"]
-                return []
-    return None
+    return errors
 
 
 def _check_on_data(cls: ast.ClassDef) -> Optional[list[str]]:
-    """Returns None if not a strategy class, [] if valid, [errors] if missing."""
+    """Returns [] if valid, [errors] if missing or bad signature."""
     for item in cls.body:
         if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == "on_data":
             return []

--- a/hqg_algorithms/validate.py
+++ b/hqg_algorithms/validate.py
@@ -1,0 +1,97 @@
+"""validate.py"""
+import ast
+from typing import Optional
+
+
+def validate_strategy(source: str) -> list[str]:
+    """
+    Validate strategy source code without executing it.
+    Returns a list of error messages. Empty list = valid.
+    """
+    errors = []
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as e:
+        return [f"Syntax error on line {e.lineno}: {e.msg}"]
+
+    # Find first class with a universe assignment
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+
+        universe = _check_universe(node)
+        cadence = _check_cadence(node)
+        on_data = _check_on_data(node)
+
+        if universe is not None:
+            # This looks like a strategy class
+            if universe:
+                errors.extend(universe)
+            if cadence:
+                errors.extend(cadence)
+            if on_data:
+                errors.extend(on_data)
+            return errors
+
+    return ["No strategy class found. Define a class with 'universe' and 'on_data'."]
+
+
+def _check_universe(cls: ast.ClassDef) -> Optional[list[str]]:
+    """Returns None if no universe found, [] if valid, [errors] if invalid."""
+    for item in cls.body:
+        if not isinstance(item, ast.Assign):
+            continue
+        for target in item.targets:
+            if isinstance(target, ast.Name) and target.id == "universe":
+                try:
+                    val = ast.literal_eval(item.value)
+                except (ValueError, TypeError):
+                    return [f"'universe' must be a list literal, e.g. [\"SPY\", \"IEF\"]"]
+                if not isinstance(val, list):
+                    return [f"'universe' must be a list, got {type(val).__name__}"]
+                if not all(isinstance(s, str) for s in val):
+                    return ["'universe' must contain only strings"]
+                if len(val) == 0:
+                    return ["'universe' must not be empty"]
+                return []
+    return None
+
+
+def _check_cadence(cls: ast.ClassDef) -> Optional[list[str]]:
+    """Returns None if no cadence found (ok, uses default), [] if valid, [errors] if invalid."""
+    VALID_BAR_SIZES = {"DAILY", "WEEKLY", "MONTHLY", "QUARTERLY"}
+    VALID_EXECUTIONS = {"CLOSE_TO_CLOSE", "CLOSE_TO_NEXT_OPEN", "OPEN_TO_OPEN"}
+
+    for item in cls.body:
+        if not isinstance(item, ast.Assign):
+            continue
+        for target in item.targets:
+            if isinstance(target, ast.Name) and target.id == "cadence":
+                node = item.value
+                if not isinstance(node, ast.Call):
+                    return ["'cadence' must be a Cadence(...) call"]
+
+                func = node.func
+                name = func.id if isinstance(func, ast.Name) else (func.attr if isinstance(func, ast.Attribute) else None)
+                if name != "Cadence":
+                    return [f"'cadence' must be a Cadence(...) call, got {name}(...)"]
+
+                for kw in node.keywords:
+                    val = kw.value
+                    if not (isinstance(val, ast.Attribute) and isinstance(val.value, ast.Name)):
+                        return [f"cadence argument '{kw.arg}' must be BarSize.X or ExecutionTiming.Y"]
+                    if kw.arg == "bar_size" and val.attr not in VALID_BAR_SIZES:
+                        return [f"Unknown bar_size '{val.attr}'. Valid: {', '.join(sorted(VALID_BAR_SIZES))}"]
+                    if kw.arg == "execution" and val.attr not in VALID_EXECUTIONS:
+                        return [f"Unknown execution '{val.attr}'. Valid: {', '.join(sorted(VALID_EXECUTIONS))}"]
+                return []
+    return None
+
+
+def _check_on_data(cls: ast.ClassDef) -> Optional[list[str]]:
+    """Returns None if not a strategy class, [] if valid, [errors] if missing."""
+    for item in cls.body:
+        if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == "on_data":
+            return []
+    return ["Missing 'on_data' method"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "hqg-algorithms"
 version = "1.0.0"
 description = "Algorithmic trading research utilities for quant teams"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 [tool.setuptools]
 packages = ["hqg_algorithms"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hqg-algorithms"
-version = "0.1.1"
+version = "1.0.0"
 description = "Algorithmic trading research utilities for quant teams"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,670 @@
+"""test_parsing_metadata.py - verify get_strategy_metadata extraction."""
+
+import pytest
+from hqg_algorithms import get_strategy_metadata, StrategyMetadata, BarSize, ExecutionTiming, Cadence
+
+
+# ── Valid strategies ─────────────────────────────────────────────────
+
+class TestValidStrategies:
+    def test_full_definition(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY", "IEF", "GLD"]
+    cadence = Cadence(bar_size=BarSize.WEEKLY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["SPY", "IEF", "GLD"]
+        assert meta.cadence.bar_size == BarSize.WEEKLY
+        assert meta.cadence.execution == ExecutionTiming.CLOSE_TO_NEXT_OPEN
+
+    def test_cadence_omitted_uses_defaults(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["AAPL"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["AAPL"]
+        assert meta.cadence == Cadence()
+        assert meta.cadence.bar_size == BarSize.DAILY
+        assert meta.cadence.execution == ExecutionTiming.CLOSE_TO_CLOSE
+
+    def test_cadence_no_args_uses_defaults(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence()
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.cadence == Cadence()
+
+    def test_cadence_bar_size_only(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=BarSize.MONTHLY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.cadence.bar_size == BarSize.MONTHLY
+        assert meta.cadence.execution == ExecutionTiming.CLOSE_TO_CLOSE
+
+    def test_cadence_execution_only(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.cadence.bar_size == BarSize.DAILY
+        assert meta.cadence.execution == ExecutionTiming.CLOSE_TO_NEXT_OPEN
+
+    @pytest.mark.parametrize("bar_size", ["DAILY", "WEEKLY", "MONTHLY", "QUARTERLY"])
+    def test_all_bar_sizes(self, bar_size):
+        meta = get_strategy_metadata(f"""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=BarSize.{bar_size})
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.cadence.bar_size == BarSize[bar_size]
+
+    @pytest.mark.parametrize("execution", ["CLOSE_TO_CLOSE", "CLOSE_TO_NEXT_OPEN"])
+    def test_all_execution_timings(self, execution):
+        meta = get_strategy_metadata(f"""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(execution=ExecutionTiming.{execution})
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.cadence.execution == ExecutionTiming[execution]
+
+    def test_single_ticker(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["AAPL"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["AAPL"]
+
+    def test_many_tickers(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["AAPL", "MSFT", "GOOG", "AMZN", "META", "TSLA", "NVDA", "BRK-B"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(meta.universe) == 8
+
+    def test_extra_class_attributes_ignored(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    some_param = 42
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=BarSize.DAILY)
+    name = "my strat"
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["SPY"]
+
+    def test_strategy_with_imports_and_comments(self):
+        meta = get_strategy_metadata("""
+# A momentum strategy
+from hqg_algorithms import Strategy, Cadence, BarSize, ExecutionTiming
+
+class MyStrategy(Strategy):
+    universe = ["SPY", "IEF"]
+    cadence = Cadence(bar_size=BarSize.WEEKLY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["SPY", "IEF"]
+        assert meta.cadence.bar_size == BarSize.WEEKLY
+
+
+# ── Return type ──────────────────────────────────────────────────────
+
+class TestReturnType:
+    def test_returns_strategy_metadata(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert isinstance(meta, StrategyMetadata)
+
+    def test_metadata_is_frozen(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        with pytest.raises(AttributeError):
+            meta.universe = ["AAPL"]
+
+
+# ── Annotated assignments ────────────────────────────────────────────
+
+class TestAnnotatedAssign:
+    def test_annotated_universe(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe: list[str] = ["SPY", "IEF"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["SPY", "IEF"]
+
+    def test_annotated_cadence(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence: Cadence = Cadence(bar_size=BarSize.WEEKLY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.cadence.bar_size == BarSize.WEEKLY
+
+    def test_annotated_both(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe: list[str] = ["SPY", "IEF"]
+    cadence: Cadence = Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["SPY", "IEF"]
+        assert meta.cadence.execution == ExecutionTiming.CLOSE_TO_NEXT_OPEN
+
+
+# ── Universe normalization ───────────────────────────────────────────
+
+class TestUniverseNormalization:
+    def test_uppercases_tickers(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["aapl", "msft"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["AAPL", "MSFT"]
+
+    def test_strips_whitespace(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["  AAPL  ", " MSFT"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["AAPL", "MSFT"]
+
+    def test_deduplicates(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY", "spy", "SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["SPY"]
+
+    def test_deduplicates_after_normalization(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["aapl", "AAPL", " aapl "]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["AAPL"]
+
+    def test_preserves_order_first_occurrence(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["IEF", "SPY", "GLD", "SPY", "IEF"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["IEF", "SPY", "GLD"]
+
+
+# ── Strategy base class detection ────────────────────────────────────
+
+class TestStrategyDetection:
+    def test_helper_class_before_strategy(self):
+        meta = get_strategy_metadata("""
+class Config:
+    universe = ["not", "a", "strategy"]
+
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["SPY"]
+
+    def test_module_qualified_base(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(hqg_algorithms.Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["SPY"]
+
+    def test_multiple_bases(self):
+        meta = get_strategy_metadata("""
+class MyStrategy(SomeMixin, Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["SPY"]
+
+    def test_first_strategy_class_wins(self):
+        meta = get_strategy_metadata("""
+class First(Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+
+class Second(Strategy):
+    universe = ["AAPL", "MSFT"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert meta.universe == ["SPY"]
+
+
+# ── Errors: no strategy found ───────────────────────────────────────
+
+class TestNoStrategyFound:
+    def test_empty_source(self):
+        with pytest.raises(ValueError, match="No strategy class"):
+            get_strategy_metadata("")
+
+    def test_no_class(self):
+        with pytest.raises(ValueError, match="No strategy class"):
+            get_strategy_metadata("x = 1\ny = 2\n")
+
+    def test_class_without_strategy_base(self):
+        with pytest.raises(ValueError, match="No strategy class"):
+            get_strategy_metadata("""
+class NotAStrategy:
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+
+# ── Errors: syntax ──────────────────────────────────────────────────
+
+class TestSyntaxError:
+    def test_invalid_python(self):
+        with pytest.raises(ValueError, match="Syntax error"):
+            get_strategy_metadata("def foo(:")
+
+    def test_unclosed_bracket(self):
+        with pytest.raises(ValueError, match="Syntax error"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY", "IEF"
+""")
+
+
+# ── Errors: bad universe ────────────────────────────────────────────
+
+class TestBadUniverse:
+    def test_universe_is_string(self):
+        with pytest.raises(ValueError, match="list"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = "AAPL"
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_is_int(self):
+        with pytest.raises(ValueError, match="list"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = 42
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_is_tuple(self):
+        with pytest.raises(ValueError, match="list"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ("SPY", "IEF")
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_empty(self):
+        with pytest.raises(ValueError, match="empty"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = []
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_has_non_string_elements(self):
+        with pytest.raises(ValueError, match="string"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["AAPL", 123]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_is_function_call(self):
+        with pytest.raises(ValueError, match="list literal"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = get_sp500()
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_is_variable(self):
+        with pytest.raises(ValueError, match="list literal"):
+            get_strategy_metadata("""
+TICKERS = ["AAPL"]
+
+class MyStrategy(Strategy):
+    universe = TICKERS
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_is_concatenation(self):
+        with pytest.raises(ValueError, match="list literal"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["AAPL"] + ["MSFT"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_is_comprehension(self):
+        with pytest.raises(ValueError, match="list literal"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = [f"T{i}" for i in range(10)]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_missing(self):
+        with pytest.raises(ValueError, match="(?i)universe"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    cadence = Cadence()
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_whitespace_ticker(self):
+        with pytest.raises(ValueError, match="empty|whitespace"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY", "  "]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_ticker_too_long(self):
+        with pytest.raises(ValueError, match="exceeds"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["THISISSUPERLONGTICKER"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_all_invalid_tickers(self):
+        with pytest.raises(ValueError):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["", "   "]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_universe_exceeds_max_size(self):
+        tickers = ", ".join(f'"T{i:04d}"' for i in range(201))
+        with pytest.raises(ValueError, match="max|200"):
+            get_strategy_metadata(f"""
+class MyStrategy(Strategy):
+    universe = [{tickers}]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+
+# ── Errors: bad cadence ─────────────────────────────────────────────
+
+class TestBadCadence:
+    def test_cadence_is_string(self):
+        with pytest.raises(ValueError, match="Cadence"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = "1d"
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_cadence_is_dict(self):
+        with pytest.raises(ValueError, match="Cadence"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = {"bar_size": "1d"}
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_cadence_wrong_function(self):
+        with pytest.raises(ValueError, match="Cadence"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = NotCadence(bar_size=BarSize.DAILY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_cadence_invalid_bar_size(self):
+        with pytest.raises(ValueError, match="bar_size"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=BarSize.HOURLY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_cadence_invalid_execution(self):
+        with pytest.raises(ValueError, match="execution"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(execution=ExecutionTiming.FAKE)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_cadence_removed_open_to_open(self):
+        with pytest.raises(ValueError, match="execution"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(execution=ExecutionTiming.OPEN_TO_OPEN)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_cadence_arg_is_variable(self):
+        with pytest.raises(ValueError, match="BarSize"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=my_var)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_cadence_arg_is_string_literal(self):
+        with pytest.raises(ValueError, match="BarSize"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size="1d")
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_cadence_positional_args(self):
+        with pytest.raises(ValueError, match="(?i)positional|keyword"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(BarSize.DAILY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_cadence_unknown_kwarg(self):
+        with pytest.raises(ValueError, match="(?i)unknown|foo"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(foo=BarSize.DAILY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+    def test_cadence_misspelled_kwarg(self):
+        with pytest.raises(ValueError, match="barsize"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(barsize=BarSize.DAILY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+
+
+# ── Errors: missing on_data ─────────────────────────────────────────
+
+class TestMissingOnData:
+    def test_no_on_data(self):
+        with pytest.raises(ValueError, match="on_data"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+""")
+
+    def test_on_data_misspelled(self):
+        with pytest.raises(ValueError, match="on_data"):
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    def ondata(self, data, portfolio):
+        pass
+""")
+
+
+# ── Error message quality ───────────────────────────────────────────
+
+class TestErrorMessages:
+    def test_multiple_errors_all_reported(self):
+        """get_strategy_metadata should surface all validation errors, not just the first."""
+        with pytest.raises(ValueError) as exc_info:
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = 42
+    cadence = "daily"
+""")
+        msg = str(exc_info.value)
+        assert "list" in msg
+        assert "Cadence" in msg
+        assert "on_data" in msg
+
+    def test_error_message_includes_all_bad_tickers(self):
+        with pytest.raises(ValueError) as exc_info:
+            get_strategy_metadata("""
+class MyStrategy(Strategy):
+    universe = ["", "THISISSUPERLONGTICKER", "   "]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        msg = str(exc_info.value)
+        assert "universe[0]" in msg or "empty" in msg
+        assert "exceeds" in msg

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,145 @@
+"""test_strategy.py - verify Strategy class variable contract and logging."""
+
+# usage: 
+# pip install -e .
+# pytest tests/ -v
+
+import pytest
+from hqg_algorithms import (
+    Strategy, Cadence, BarSize, ExecutionTiming,
+)
+
+
+# ── Class variable contract ──────────────────────────────────────────
+
+class TestStrategyClassVariables:
+    def test_missing_universe_raises(self):
+        with pytest.raises(TypeError, match="universe"):
+            class BadStrategy(Strategy):
+                cadence = Cadence()
+
+                def on_data(self, data, portfolio):
+                    pass
+
+    def test_universe_not_a_list_raises(self):
+        with pytest.raises(TypeError, match="universe"):
+            class BadStrategy(Strategy):
+                universe = "AAPL"
+
+                def on_data(self, data, portfolio):
+                    pass
+
+    def test_cadence_defaults_when_omitted(self):
+        class MinimalStrategy(Strategy):
+            universe = ["AAPL"]
+
+            def on_data(self, data, portfolio):
+                pass
+
+        assert MinimalStrategy.cadence == Cadence()
+        assert MinimalStrategy.cadence.bar_size == BarSize.DAILY
+        assert MinimalStrategy.cadence.execution == ExecutionTiming.CLOSE_TO_CLOSE
+
+    def test_valid_strategy_definition(self):
+        class GoodStrategy(Strategy):
+            universe = ["SPY", "IEF", "GLD"]
+            cadence = Cadence(bar_size=BarSize.WEEKLY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
+
+            def on_data(self, data, portfolio):
+                pass
+
+        assert GoodStrategy.universe == ["SPY", "IEF", "GLD"]
+        assert GoodStrategy.cadence.bar_size == BarSize.WEEKLY
+
+    def test_empty_universe_raises(self):
+        with pytest.raises(TypeError, match="universe"):
+            class BadStrategy(Strategy):
+                universe = []
+
+                def on_data(self, data, portfolio):
+                    pass
+
+
+# ── Logging ──────────────────────────────────────────────────────────
+
+class TestStrategyLogging:
+    def _make_strategy(self):
+        class DummyStrategy(Strategy):
+            universe = ["SPY"]
+
+            def on_data(self, data, portfolio):
+                pass
+
+        return DummyStrategy()
+
+    def test_default_log_handler_is_print(self, capsys):
+        s = self._make_strategy()
+        s.log("hello")
+        assert capsys.readouterr().out.strip() == "hello"
+
+    def test_override_log_handler_on_instance(self):
+        s = self._make_strategy()
+        captured = []
+        s._log_handler = captured.append
+        s.log("msg1")
+        s.log("msg2")
+        assert captured == ["msg1", "msg2"]
+
+    def test_override_log_handler_on_class(self):
+        captured = []
+
+        class LoggingStrategy(Strategy):
+            universe = ["SPY"]
+            _log_handler = staticmethod(captured.append)
+
+            def on_data(self, data, portfolio):
+                pass
+
+        a = LoggingStrategy()
+        b = LoggingStrategy()
+        a.log("from_a")
+        b.log("from_b")
+        assert captured == ["from_a", "from_b"]
+
+    def test_instance_override_does_not_affect_other_instances(self, capsys):
+        s1 = self._make_strategy()
+        s2 = self._make_strategy()
+        captured = []
+        s1._log_handler = captured.append
+        s2.log("to_print")
+        s1.log("to_list")
+        assert captured == ["to_list"]
+        assert "to_print" in capsys.readouterr().out
+
+    def test_log_handler_receives_exact_string(self):
+        s = self._make_strategy()
+        received = []
+        s._log_handler = received.append
+        msg = "  spaces & special chars! 🚀\n"
+        s.log(msg)
+        assert received == [msg]
+
+    def test_override_with_lambda(self):
+        s = self._make_strategy()
+        results = []
+        s._log_handler = lambda m: results.append(m.upper())
+        s.log("hello")
+        assert results == ["HELLO"]
+
+    def test_subclass_override_does_not_affect_base_default(self):
+        captured = []
+
+        class CustomStrategy(Strategy):
+            universe = ["SPY"]
+            _log_handler = staticmethod(captured.append)
+
+            def on_data(self, data, portfolio):
+                pass
+
+        class OtherStrategy(Strategy):
+            universe = ["IEF"]
+
+            def on_data(self, data, portfolio):
+                pass
+
+        assert OtherStrategy._log_handler is not CustomStrategy._log_handler

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -251,7 +251,7 @@ class TestCadenceImmutability:
     def test_cannot_set_execution(self):
         c = Cadence()
         with pytest.raises(AttributeError):
-            c.execution = ExecutionTiming.OPEN_TO_OPEN
+            c.execution = ExecutionTiming.CLOSE_TO_CLOSE
 
 
 # ── Hold / Liquidate ────────────────────────────────────────────────

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,264 @@
+"""test_types.py - verify all read-only protections on types."""
+
+import pytest
+from hqg_algorithms import (
+    Bar, Slice, PortfolioView, TargetWeights, Hold, Liquidate,
+    Cadence, BarSize, ExecutionTiming,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+@pytest.fixture
+def bar():
+    return Bar(open=100.0, high=105.0, low=99.0, close=104.0, volume=1e6)
+
+
+@pytest.fixture
+def slice_data(bar):
+    return Slice({"SPY": bar, "IEF": Bar(open=97.0, high=97.5, low=96.8, close=97.3, volume=4e6)})
+
+
+@pytest.fixture
+def portfolio():
+    return PortfolioView(
+        equity=100_000.0,
+        cash=20_000.0,
+        positions={"SPY": 100, "IEF": 200},
+        weights={"SPY": 0.6, "IEF": 0.4},
+    )
+
+
+# ── Bar (frozen dataclass) ──────────────────────────────────────────
+
+class TestBarImmutability:
+    def test_cannot_set_attribute(self, bar):
+        with pytest.raises(AttributeError):
+            bar.open = 999.0
+
+    def test_cannot_set_any_field(self, bar):
+        for field in ("open", "high", "low", "close", "volume"):
+            with pytest.raises(AttributeError):
+                setattr(bar, field, 0.0)
+
+    def test_cannot_delete_attribute(self, bar):
+        with pytest.raises(AttributeError):
+            del bar.open
+
+    def test_cannot_add_new_attribute(self, bar):
+        with pytest.raises(AttributeError):
+            bar.vwap = 102.0
+
+
+# ── Slice (Mapping-based, read-only) ────────────────────────────────
+
+class TestSliceReadAccess:
+    def test_getitem(self, slice_data, bar):
+        assert slice_data["SPY"] == bar
+
+    def test_get_missing_returns_none(self, slice_data):
+        assert slice_data.get("AAPL") is None
+
+    def test_contains(self, slice_data):
+        assert "SPY" in slice_data
+        assert "AAPL" not in slice_data
+
+    def test_len(self, slice_data):
+        assert len(slice_data) == 2
+
+    def test_iter(self, slice_data):
+        assert set(slice_data) == {"SPY", "IEF"}
+
+    def test_keys_values_items(self, slice_data):
+        assert set(slice_data.keys()) == {"SPY", "IEF"}
+        assert len(list(slice_data.values())) == 2
+        assert len(list(slice_data.items())) == 2
+
+    def test_symbols(self, slice_data):
+        assert set(slice_data.symbols()) == {"SPY", "IEF"}
+
+    def test_has(self, slice_data):
+        assert slice_data.has("SPY")
+        assert not slice_data.has("AAPL")
+
+    def test_bar(self, slice_data, bar):
+        assert slice_data.bar("SPY") == bar
+        assert slice_data.bar("AAPL") is None
+
+    def test_ohlcv_helpers(self, slice_data):
+        assert slice_data.open("SPY") == 100.0
+        assert slice_data.high("SPY") == 105.0
+        assert slice_data.low("SPY") == 99.0
+        assert slice_data.close("SPY") == 104.0
+        assert slice_data.volume("SPY") == 1e6
+
+    def test_ohlcv_helpers_missing(self, slice_data):
+        assert slice_data.open("AAPL") is None
+        assert slice_data.close("AAPL") is None
+
+
+class TestSliceImmutability:
+    def test_cannot_setitem(self, slice_data, bar):
+        with pytest.raises(TypeError):
+            slice_data["AAPL"] = bar
+
+    def test_cannot_delitem(self, slice_data):
+        with pytest.raises(TypeError):
+            del slice_data["SPY"]
+
+    def test_no_pop(self, slice_data):
+        assert not hasattr(slice_data, "pop")
+
+    def test_no_clear(self, slice_data):
+        assert not hasattr(slice_data, "clear")
+
+    def test_no_update(self, slice_data):
+        assert not hasattr(slice_data, "update")
+
+    def test_no_setdefault(self, slice_data):
+        assert not hasattr(slice_data, "setdefault")
+
+    def test_no_popitem(self, slice_data):
+        assert not hasattr(slice_data, "popitem")
+
+    def test_no_ior(self, slice_data, bar):
+        with pytest.raises(TypeError):
+            slice_data |= {"AAPL": bar}
+
+    def test_caller_mutation_does_not_affect_slice(self):
+        original = {"SPY": Bar(open=1, high=2, low=0.5, close=1.5, volume=100)}
+        s = Slice(original)
+        original["AAPL"] = Bar(open=9, high=9, low=9, close=9, volume=9)
+        assert "AAPL" not in s
+        assert len(s) == 1
+
+
+# ── PortfolioView (frozen dataclass + MappingProxyType) ─────────────
+
+class TestPortfolioViewImmutability:
+    def test_cannot_set_equity(self, portfolio):
+        with pytest.raises(AttributeError):
+            portfolio.equity = 999.0
+
+    def test_cannot_set_cash(self, portfolio):
+        with pytest.raises(AttributeError):
+            portfolio.cash = 999.0
+
+    def test_cannot_reassign_positions(self, portfolio):
+        with pytest.raises(AttributeError):
+            portfolio.positions = {}
+
+    def test_cannot_reassign_weights(self, portfolio):
+        with pytest.raises(AttributeError):
+            portfolio.weights = {}
+
+    def test_cannot_mutate_positions_dict(self, portfolio):
+        with pytest.raises(TypeError):
+            portfolio.positions["SPY"] = 9999
+
+    def test_cannot_mutate_weights_dict(self, portfolio):
+        with pytest.raises(TypeError):
+            portfolio.weights["SPY"] = 0.99
+
+    def test_no_pop_positions(self, portfolio):
+        assert not hasattr(portfolio.positions, "pop")
+
+    def test_no_clear_weights(self, portfolio):
+        assert not hasattr(portfolio.weights, "clear")
+
+    def test_no_update_positions(self, portfolio):
+        assert not hasattr(portfolio.positions, "update")
+
+    def test_cannot_delete_positions_key(self, portfolio):
+        with pytest.raises(TypeError):
+            del portfolio.positions["SPY"]
+
+    def test_caller_mutation_does_not_affect_portfolio(self):
+        pos = {"SPY": 100}
+        wts = {"SPY": 1.0}
+        pv = PortfolioView(equity=50_000, cash=0, positions=pos, weights=wts)
+        pos["AAPL"] = 200
+        wts["AAPL"] = 0.5
+        assert "AAPL" not in pv.positions
+        assert "AAPL" not in pv.weights
+
+    def test_read_access_works(self, portfolio):
+        assert portfolio.equity == 100_000.0
+        assert portfolio.cash == 20_000.0
+        assert portfolio.positions["SPY"] == 100
+        assert portfolio.weights["IEF"] == 0.4
+
+
+# ── TargetWeights (frozen + validation + MappingProxyType) ──────────
+
+class TestTargetWeightsValidation:
+    def test_valid_weights(self):
+        tw = TargetWeights(weights={"SPY": 0.6, "IEF": 0.4})
+        assert tw.weights["SPY"] == 0.6
+
+    def test_weights_under_one_ok(self):
+        tw = TargetWeights(weights={"SPY": 0.3})
+        assert tw.weights["SPY"] == 0.3
+
+    def test_empty_weights_ok(self):
+        tw = TargetWeights(weights={})
+        assert len(tw.weights) == 0
+
+    def test_negative_weight_raises(self):
+        with pytest.raises(ValueError, match="Negative"):
+            TargetWeights(weights={"SPY": -0.1})
+
+    def test_weights_exceeding_one_raises(self):
+        with pytest.raises(ValueError, match="exceeds 1.0"):
+            TargetWeights(weights={"SPY": 0.6, "IEF": 0.5})
+
+
+class TestTargetWeightsImmutability:
+    def test_cannot_reassign_weights(self):
+        tw = TargetWeights(weights={"SPY": 0.5})
+        with pytest.raises(AttributeError):
+            tw.weights = {"IEF": 1.0}
+
+    def test_cannot_mutate_weights_dict(self):
+        tw = TargetWeights(weights={"SPY": 0.5})
+        with pytest.raises(TypeError):
+            tw.weights["SPY"] = -1.0
+
+    def test_cannot_add_to_weights_dict(self):
+        tw = TargetWeights(weights={"SPY": 0.5})
+        with pytest.raises(TypeError):
+            tw.weights["AAPL"] = 0.3
+
+    def test_no_pop_weights(self):
+        tw = TargetWeights(weights={"SPY": 0.5})
+        assert not hasattr(tw.weights, "pop")
+
+    def test_caller_mutation_does_not_bypass_validation(self):
+        w = {"SPY": 0.5}
+        tw = TargetWeights(weights=w)
+        w["SPY"] = -99.0
+        assert tw.weights["SPY"] == 0.5
+
+
+# ── Cadence (frozen dataclass) ──────────────────────────────────────
+
+class TestCadenceImmutability:
+    def test_cannot_set_bar_size(self):
+        c = Cadence()
+        with pytest.raises(AttributeError):
+            c.bar_size = BarSize.WEEKLY
+
+    def test_cannot_set_execution(self):
+        c = Cadence()
+        with pytest.raises(AttributeError):
+            c.execution = ExecutionTiming.OPEN_TO_OPEN
+
+
+# ── Hold / Liquidate ────────────────────────────────────────────────
+
+class TestSignalTypes:
+    def test_hold_instantiates(self):
+        assert Hold() is not None
+
+    def test_liquidate_instantiates(self):
+        assert Liquidate() is not None

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -18,21 +18,6 @@ class MyStrategy(Strategy):
 """)
         assert errors == []
 
-    def test_addnl_class(self):
-        errors = validate_strategy("""
-class Helper:
-    # universe = comment
-    x = 10
-
-class MyStrategy(Strategy):
-    universe = ["SPY", "IEF", "GLD"]
-    cadence = Cadence(bar_size=BarSize.WEEKLY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
-
-    def on_data(self, data, portfolio):
-        pass
-""")
-        assert errors == []
-
     def test_minimal_no_cadence(self):
         errors = validate_strategy("""
 class MyStrategy(Strategy):
@@ -76,7 +61,7 @@ class MyStrategy(Strategy):
 """)
         assert errors == []
 
-    def test_extra_attributes_ignored(self):
+    def test_extra_class_attributes_ignored(self):
         errors = validate_strategy("""
 class MyStrategy(Strategy):
     universe = ["SPY"]
@@ -98,6 +83,188 @@ class MyStrategy(Strategy):
 """)
         assert errors == []
 
+    @pytest.mark.parametrize("bar_size", ["DAILY", "WEEKLY", "MONTHLY", "QUARTERLY"])
+    def test_all_valid_bar_sizes(self, bar_size):
+        errors = validate_strategy(f"""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=BarSize.{bar_size})
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    @pytest.mark.parametrize("execution", ["CLOSE_TO_CLOSE", "CLOSE_TO_NEXT_OPEN"])
+    def test_all_valid_execution_timings(self, execution):
+        errors = validate_strategy(f"""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(execution=ExecutionTiming.{execution})
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_on_data_with_extra_methods(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    def helper(self):
+        pass
+
+    def on_data(self, data, portfolio):
+        pass
+
+    def another_helper(self):
+        pass
+""")
+        assert errors == []
+
+    def test_on_data_as_async(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    async def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+
+# ── Annotated assignments (ast.AnnAssign) ────────────────────────────
+
+class TestAnnotatedAssign:
+    def test_annotated_universe(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe: list[str] = ["SPY", "IEF"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_annotated_cadence(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence: Cadence = Cadence(bar_size=BarSize.WEEKLY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_annotated_both(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe: list[str] = ["SPY", "IEF"]
+    cadence: Cadence = Cadence(bar_size=BarSize.DAILY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_annotation_only_no_value_is_missing(self):
+        """universe: list[str] without assignment should be treated as missing."""
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe: list[str]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("universe" in e.lower() or "missing" in e.lower() for e in errors)
+
+    def test_annotated_bad_universe_type(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe: str = "AAPL"
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("list" in e for e in errors)
+
+
+# ── Strategy base class detection ────────────────────────────────────
+
+class TestStrategyDetection:
+    def test_helper_class_with_universe_before_strategy(self):
+        """Should skip non-Strategy classes even if they have universe."""
+        errors = validate_strategy("""
+class Config:
+    universe = ["not", "a", "strategy"]
+
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_helper_class_with_universe_only(self):
+        """Class with universe but not inheriting Strategy should not be found."""
+        errors = validate_strategy("""
+class NotAStrategy:
+    universe = ["SPY", "IEF"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("No strategy class" in e for e in errors)
+
+    def test_module_qualified_strategy_base(self):
+        """class MyStrategy(hqg_algorithms.Strategy) should be detected."""
+        errors = validate_strategy("""
+class MyStrategy(hqg_algorithms.Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_multiple_bases_with_strategy(self):
+        errors = validate_strategy("""
+class MyStrategy(SomeMixin, Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_multiple_strategy_classes_validates_first(self):
+        """If multiple Strategy subclasses exist, validate the first one."""
+        errors = validate_strategy("""
+class First(Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+
+class Second(Strategy):
+    universe = 42
+""")
+        assert errors == []
+
+    def test_universe_in_init_not_detected(self):
+        """self.universe = [...] inside __init__ should not count."""
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    def __init__(self):
+        self.universe = ["SPY"]
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("universe" in e.lower() or "missing" in e.lower() for e in errors)
+
 
 # ── No strategy found ────────────────────────────────────────────────
 
@@ -112,7 +279,7 @@ class TestNoStrategy:
         assert len(errors) == 1
         assert "No strategy class" in errors[0]
 
-    def test_class_without_universe_or_on_data(self):
+    def test_class_without_strategy_base(self):
         errors = validate_strategy("""
 class Foo:
     x = 1
@@ -120,15 +287,13 @@ class Foo:
         assert len(errors) == 1
         assert "No strategy class" in errors[0]
 
-    def test_universe_in_method_not_detected(self):
+    def test_only_comments_and_imports(self):
         errors = validate_strategy("""
-class MyStrategy(Strategy):
-    def __init__(self):
-        self.universe = ["SPY"]
-    def on_data(self, data, portfolio):
-        pass
-    """)
-        assert "No strategy class" in errors[0]
+# this is a comment
+import numpy as np
+from hqg_algorithms import Strategy
+""")
+        assert any("No strategy class" in e for e in errors)
 
 
 # ── Syntax errors ────────────────────────────────────────────────────
@@ -147,6 +312,14 @@ class MyStrategy(Strategy):
         assert len(errors) == 1
         assert "Syntax error" in errors[0]
 
+    def test_indentation_error(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+universe = ["SPY"]
+""")
+        assert len(errors) == 1
+        assert "Syntax error" in errors[0]
+
 
 # ── Bad universe ─────────────────────────────────────────────────────
 
@@ -159,8 +332,7 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "list" in errors[0]
+        assert any("list" in e for e in errors)
 
     def test_universe_is_int(self):
         errors = validate_strategy("""
@@ -170,8 +342,27 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "list" in errors[0]
+        assert any("list" in e for e in errors)
+
+    def test_universe_is_tuple(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ("SPY", "IEF")
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("list" in e for e in errors)
+
+    def test_universe_is_dict(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = {"SPY": 0.5}
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("list" in e for e in errors)
 
     def test_universe_has_non_string_elements(self):
         errors = validate_strategy("""
@@ -181,8 +372,17 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "strings" in errors[0]
+        assert any("string" in e for e in errors)
+
+    def test_universe_has_mixed_types(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["AAPL", 123, None, True]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len([e for e in errors if "string" in e or "expected" in e]) >= 1
 
     def test_universe_empty(self):
         errors = validate_strategy("""
@@ -192,8 +392,7 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "empty" in errors[0]
+        assert any("empty" in e for e in errors)
 
     def test_universe_is_function_call(self):
         errors = validate_strategy("""
@@ -203,8 +402,7 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "list literal" in errors[0]
+        assert any("list literal" in e for e in errors)
 
     def test_universe_is_variable(self):
         errors = validate_strategy("""
@@ -216,8 +414,7 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "list literal" in errors[0]
+        assert any("list literal" in e for e in errors)
 
     def test_universe_is_concatenation(self):
         errors = validate_strategy("""
@@ -227,8 +424,136 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "list literal" in errors[0]
+        assert any("list literal" in e for e in errors)
+
+    def test_universe_is_comprehension(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = [f"STOCK_{i}" for i in range(10)]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("list literal" in e for e in errors)
+
+    def test_universe_missing_from_strategy(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    cadence = Cadence()
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("universe" in e.lower() or "missing" in e.lower() for e in errors)
+
+
+# ── Universe ticker cleaning ─────────────────────────────────────────
+
+class TestUniverseCleaning:
+    def test_empty_string_ticker(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = [""]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("empty" in e or "whitespace" in e for e in errors)
+
+    def test_whitespace_only_ticker(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["   "]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("empty" in e or "whitespace" in e for e in errors)
+
+    def test_ticker_exceeds_max_length(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["THISISSUPERLONGTICKER"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("exceeds" in e or "characters" in e for e in errors)
+
+    def test_ticker_at_max_length_ok(self):
+        # MAX_TICKER_LEN = 12
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["ABCDEFGHIJKL"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_all_duplicates_yields_error(self):
+        """["SPY", "SPY", "SPY"] → after dedup, still valid (1 ticker)."""
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY", "SPY", "SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_all_empty_strings(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["", "  ", ""]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) >= 1
+
+    def test_mix_valid_and_invalid_tickers(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY", "", "THISISSUPERLONGTICKER", "IEF"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) >= 2  # empty + too long
+
+    def test_all_invalid_tickers_no_valid_remaining(self):
+        """All tickers invalid → should get per-ticker errors + no valid tickers error."""
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["", "   "]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("no valid" in e.lower() or "empty" in e.lower() for e in errors)
+
+    def test_universe_exceeds_max_size(self):
+        tickers = ", ".join(f'"T{i:04d}"' for i in range(201))
+        errors = validate_strategy(f"""
+class MyStrategy(Strategy):
+    universe = [{tickers}]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("max" in e.lower() or "200" in e for e in errors)
+
+    def test_universe_at_max_size_ok(self):
+        tickers = ", ".join(f'"T{i:04d}"' for i in range(200))
+        errors = validate_strategy(f"""
+class MyStrategy(Strategy):
+    universe = [{tickers}]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
 
 
 # ── Bad cadence ──────────────────────────────────────────────────────
@@ -243,8 +568,7 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "Cadence(...)" in errors[0]
+        assert any("Cadence(...)" in e for e in errors)
 
     def test_cadence_is_dict(self):
         errors = validate_strategy("""
@@ -255,8 +579,18 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "Cadence(...)" in errors[0]
+        assert any("Cadence(...)" in e for e in errors)
+
+    def test_cadence_is_int(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = 5
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("Cadence(...)" in e for e in errors)
 
     def test_cadence_wrong_function(self):
         errors = validate_strategy("""
@@ -267,8 +601,7 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "Cadence(...)" in errors[0]
+        assert any("Cadence(...)" in e for e in errors)
 
     def test_cadence_invalid_bar_size(self):
         errors = validate_strategy("""
@@ -279,8 +612,7 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "bar_size" in errors[0]
+        assert any("bar_size" in e for e in errors)
 
     def test_cadence_invalid_execution(self):
         errors = validate_strategy("""
@@ -291,8 +623,7 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "execution" in errors[0]
+        assert any("execution" in e for e in errors)
 
     def test_cadence_arg_is_variable(self):
         errors = validate_strategy("""
@@ -303,8 +634,7 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "BarSize.X" in errors[0]
+        assert any("BarSize.X" in e or "ExecutionTiming.Y" in e for e in errors)
 
     def test_cadence_arg_is_string_literal(self):
         errors = validate_strategy("""
@@ -315,8 +645,99 @@ class MyStrategy(Strategy):
     def on_data(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "BarSize.X" in errors[0]
+        assert any("BarSize.X" in e or "ExecutionTiming.Y" in e for e in errors)
+
+    def test_cadence_arg_is_int_literal(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=1)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("BarSize.X" in e or "ExecutionTiming.Y" in e for e in errors)
+
+    def test_cadence_arg_is_function_call(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=get_bar_size())
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("BarSize.X" in e or "ExecutionTiming.Y" in e for e in errors)
+
+    def test_cadence_positional_args_rejected(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(BarSize.DAILY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("positional" in e.lower() or "keyword" in e.lower() for e in errors)
+
+
+# ── Unknown cadence kwargs ───────────────────────────────────────────
+
+class TestUnknownCadenceKwargs:
+    def test_single_unknown_kwarg(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(foo=BarSize.DAILY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("unknown" in e.lower() or "foo" in e for e in errors)
+
+    def test_multiple_unknown_kwargs(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(foo=BarSize.DAILY, baz=ExecutionTiming.CLOSE_TO_CLOSE)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("foo" in e or "baz" in e for e in errors)
+
+    def test_valid_plus_unknown_kwarg(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=BarSize.DAILY, typo=BarSize.WEEKLY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("typo" in e for e in errors)
+
+    def test_misspelled_bar_size(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(barsize=BarSize.DAILY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("barsize" in e for e in errors)
+
+    def test_misspelled_execution(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(exec=ExecutionTiming.CLOSE_TO_CLOSE)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("exec" in e for e in errors)
 
 
 # ── Missing on_data ──────────────────────────────────────────────────
@@ -328,8 +749,7 @@ class MyStrategy(Strategy):
     universe = ["SPY"]
     cadence = Cadence()
 """)
-        assert len(errors) == 1
-        assert "on_data" in errors[0]
+        assert any("on_data" in e for e in errors)
 
     def test_on_data_misspelled(self):
         errors = validate_strategy("""
@@ -339,10 +759,17 @@ class MyStrategy(Strategy):
     def ondata(self, data, portfolio):
         pass
 """)
-        assert len(errors) == 1
-        assert "on_data" in errors[0]
+        assert any("on_data" in e for e in errors)
 
-    def test_on_data_nested_not_detected(self):
+    def test_on_data_as_class_variable_not_method(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    on_data = None
+""")
+        assert any("on_data" in e for e in errors)
+
+    def test_on_data_nested_in_other_method(self):
         errors = validate_strategy("""
 class MyStrategy(Strategy):
     universe = ["SPY"]
@@ -352,8 +779,17 @@ class MyStrategy(Strategy):
 """)
         assert any("on_data" in e for e in errors)
 
+    def test_on_data_as_lambda_not_detected(self):
+        """on_data = lambda ... is an Assign, not a FunctionDef."""
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    on_data = lambda self, data, portfolio: None
+""")
+        assert any("on_data" in e for e in errors)
 
-# ── Multiple errors ──────────────────────────────────────────────────
+
+# ── Multiple errors accumulate ───────────────────────────────────────
 
 class TestMultipleErrors:
     def test_bad_universe_and_missing_on_data(self):
@@ -372,3 +808,142 @@ class MyStrategy(Strategy):
     cadence = "daily"
 """)
         assert len(errors) == 3
+
+    def test_missing_universe_and_bad_cadence_and_missing_on_data(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    cadence = "daily"
+""")
+        assert len(errors) >= 2  # missing universe + bad cadence (+ missing on_data = 3)
+        assert any("universe" in e.lower() or "missing" in e.lower() for e in errors)
+
+    def test_bad_cadence_with_multiple_issues(self):
+        """Invalid bar_size AND invalid execution should both be reported."""
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=BarSize.HOURLY, execution=ExecutionTiming.FAKE)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert any("bar_size" in e for e in errors)
+        assert any("execution" in e for e in errors)
+
+    def test_multiple_bad_tickers_all_reported(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["", "THISISSUPERLONGTICKER", "   "]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len([e for e in errors if "universe[" in e]) >= 2
+
+
+# ── Edge cases ───────────────────────────────────────────────────────
+
+class TestEdgeCases:
+    def test_single_ticker_valid(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_unicode_in_source(self):
+        errors = validate_strategy("""
+# Strategy for 日本株
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_decorator_on_strategy_class(self):
+        errors = validate_strategy("""
+@some_decorator
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_strategy_with_docstring(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    \"\"\"A momentum strategy.\"\"\"
+    universe = ["SPY", "IEF"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_strategy_with_init(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    def __init__(self):
+        super().__init__()
+        self.lookback = 20
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_strategy_with_complex_on_data_body(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY", "IEF"]
+
+    def on_data(self, data, portfolio):
+        spy = data["SPY"]
+        if spy.close > spy.open:
+            return TargetWeights({"SPY": 0.6, "IEF": 0.4})
+        return Hold()
+""")
+        assert errors == []
+
+    def test_whitespace_heavy_source(self):
+        errors = validate_strategy("""
+
+
+class MyStrategy(Strategy):
+
+    universe = ["SPY"]
+
+
+    def on_data(self, data, portfolio):
+
+        pass
+
+""")
+        assert errors == []
+
+    def test_only_whitespace_source(self):
+        errors = validate_strategy("   \n\n  \n   ")
+        assert any("No strategy class" in e for e in errors)
+
+    def test_nested_class_not_confused(self):
+        """Inner class shouldn't be validated as the strategy."""
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    class Inner:
+        universe = 42  # should be ignored
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,374 @@
+"""test_validate.py - verify AST-based strategy validation."""
+
+import pytest
+from hqg_algorithms import validate_strategy
+
+
+# ── Valid strategies return no errors ────────────────────────────────
+
+class TestValid:
+    def test_full_definition(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY", "IEF", "GLD"]
+    cadence = Cadence(bar_size=BarSize.WEEKLY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_addnl_class(self):
+        errors = validate_strategy("""
+class Helper:
+    # universe = comment
+    x = 10
+
+class MyStrategy(Strategy):
+    universe = ["SPY", "IEF", "GLD"]
+    cadence = Cadence(bar_size=BarSize.WEEKLY, execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_minimal_no_cadence(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["AAPL"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_cadence_no_args(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence()
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_cadence_bar_size_only(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=BarSize.MONTHLY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_cadence_execution_only(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(execution=ExecutionTiming.CLOSE_TO_NEXT_OPEN)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_extra_attributes_ignored(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    some_param = 42
+    name = "test"
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+    def test_many_tickers(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["AAPL", "MSFT", "GOOG", "AMZN", "META", "TSLA", "NVDA", "BRK-B"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert errors == []
+
+
+# ── No strategy found ────────────────────────────────────────────────
+
+class TestNoStrategy:
+    def test_empty_source(self):
+        errors = validate_strategy("")
+        assert len(errors) == 1
+        assert "No strategy class" in errors[0]
+
+    def test_no_class(self):
+        errors = validate_strategy("x = 1\ny = 2\n")
+        assert len(errors) == 1
+        assert "No strategy class" in errors[0]
+
+    def test_class_without_universe_or_on_data(self):
+        errors = validate_strategy("""
+class Foo:
+    x = 1
+""")
+        assert len(errors) == 1
+        assert "No strategy class" in errors[0]
+
+    def test_universe_in_method_not_detected(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    def __init__(self):
+        self.universe = ["SPY"]
+    def on_data(self, data, portfolio):
+        pass
+    """)
+        assert "No strategy class" in errors[0]
+
+
+# ── Syntax errors ────────────────────────────────────────────────────
+
+class TestSyntaxErrors:
+    def test_invalid_python(self):
+        errors = validate_strategy("def foo(:")
+        assert len(errors) == 1
+        assert "Syntax error" in errors[0]
+
+    def test_unclosed_bracket(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY", "IEF"
+""")
+        assert len(errors) == 1
+        assert "Syntax error" in errors[0]
+
+
+# ── Bad universe ─────────────────────────────────────────────────────
+
+class TestBadUniverse:
+    def test_universe_is_string(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = "AAPL"
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "list" in errors[0]
+
+    def test_universe_is_int(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = 42
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "list" in errors[0]
+
+    def test_universe_has_non_string_elements(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["AAPL", 123]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "strings" in errors[0]
+
+    def test_universe_empty(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = []
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "empty" in errors[0]
+
+    def test_universe_is_function_call(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = get_sp500()
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "list literal" in errors[0]
+
+    def test_universe_is_variable(self):
+        errors = validate_strategy("""
+TICKERS = ["AAPL"]
+
+class MyStrategy(Strategy):
+    universe = TICKERS
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "list literal" in errors[0]
+
+    def test_universe_is_concatenation(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["AAPL"] + ["MSFT"]
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "list literal" in errors[0]
+
+
+# ── Bad cadence ──────────────────────────────────────────────────────
+
+class TestBadCadence:
+    def test_cadence_is_string(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = "1d"
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "Cadence(...)" in errors[0]
+
+    def test_cadence_is_dict(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = {"bar_size": "1d"}
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "Cadence(...)" in errors[0]
+
+    def test_cadence_wrong_function(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = NotCadence(bar_size=BarSize.DAILY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "Cadence(...)" in errors[0]
+
+    def test_cadence_invalid_bar_size(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=BarSize.HOURLY)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "bar_size" in errors[0]
+
+    def test_cadence_invalid_execution(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(execution=ExecutionTiming.FAKE)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "execution" in errors[0]
+
+    def test_cadence_arg_is_variable(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size=my_var)
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "BarSize.X" in errors[0]
+
+    def test_cadence_arg_is_string_literal(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence(bar_size="1d")
+
+    def on_data(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "BarSize.X" in errors[0]
+
+
+# ── Missing on_data ──────────────────────────────────────────────────
+
+class TestMissingOnData:
+    def test_no_on_data_method(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    cadence = Cadence()
+""")
+        assert len(errors) == 1
+        assert "on_data" in errors[0]
+
+    def test_on_data_misspelled(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+
+    def ondata(self, data, portfolio):
+        pass
+""")
+        assert len(errors) == 1
+        assert "on_data" in errors[0]
+
+    def test_on_data_nested_not_detected(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = ["SPY"]
+    def __init__(self):
+        def on_data():
+            pass
+""")
+        assert any("on_data" in e for e in errors)
+
+
+# ── Multiple errors ──────────────────────────────────────────────────
+
+class TestMultipleErrors:
+    def test_bad_universe_and_missing_on_data(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = "AAPL"
+""")
+        assert len(errors) == 2
+        assert any("list" in e for e in errors)
+        assert any("on_data" in e for e in errors)
+
+    def test_bad_universe_and_bad_cadence_and_missing_on_data(self):
+        errors = validate_strategy("""
+class MyStrategy(Strategy):
+    universe = 42
+    cadence = "daily"
+""")
+        assert len(errors) == 3


### PR DESCRIPTION
**Changes**
- **Typed Bar model** (#7) - `Slice` now maps symbols to a `Bar` dataclass instead of `dict[str, dict[str, float]]`, giving us IDE autocomplete and compile-time field checking.
- **Explicit Signal types** (#6) - `on_data()` returns `TargetWeights`, `Hold`, or `Liquidate` instead of `dict | None`. No longer need to remember that `{}` means liquidate while None means no change. 
- **Weight validation** - `TargetWeights` rejects negative weights and sums above 1.0 at construction. These errors would be unintentional, so not something we should try to clamp or normalize.
- **ExecutionTiming enum** - Replaces `call_phase` + `exec_lag_bars` with a single enum (`CLOSE_TO_NEXT_OPEN`, `CLOSE_TO_CLOSE`, `OPEN_TO_OPEN`), eliminating invalid combinations. Ie, lag 0 days & execute on open (get data on t's close, execute on t's open).

**Breaking changes**
This is intentionally breaking. The goal is to get all breaking changes before v1 so that post-v1 releases are additive only.

Services will need to update:
- `dict[str, dict[str, float]]` -> `Bar` (anywhere Slice data is constructed or consumed)
- `dict[str, float] | None` -> `Signal` objects (anywhere on_data results are handled)
- `CallPhase` / `exec_lag_bars` -> `ExecutionTiming`