### PR TITLE
fix: extract_metadata function

### DIFF
--- a/hqg_algorithms/__init__.py
+++ b/hqg_algorithms/__init__.py
@@ -4,11 +4,13 @@ from .types import (
     Cadence, Slice, Bar, PortfolioView, BarSize, ExecutionTiming,
     Signal, TargetWeights, Hold, Liquidate,
 )
-from .parsing import validate_strategy, get_strategy_metadata, StrategyMetadata
+from .parsing import (
+    validate_strategy, get_strategy_metadata, extract_metadata, StrategyMetadata
+)
 
 __all__ = [
     "Strategy", "Cadence", "Slice", "Bar", "PortfolioView",
     "BarSize", "ExecutionTiming",
     "Signal", "TargetWeights", "Hold", "Liquidate",
-    "validate_strategy", "get_strategy_metadata", "StrategyMetadata",
+    "validate_strategy", "get_strategy_metadata", "extract_metadata", "StrategyMetadata",
 ]

--- a/hqg_algorithms/parsing.py
+++ b/hqg_algorithms/parsing.py
@@ -84,6 +84,11 @@ def get_strategy_metadata(source: str) -> StrategyMetadata:
     return StrategyMetadata(universe=universe, cadence=cadence)
 
 
+# Backward-compatible public alias used by hqg-backtester.
+def extract_metadata(source: str) -> StrategyMetadata:
+    return get_strategy_metadata(source)
+
+
 
 ### parsing helpers
 def _is_strategy_subclass(node: ast.ClassDef) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hqg-algorithms"
-version = "1.0.0"
+version = "1.0.1"
 description = "Algorithmic trading research utilities for quant teams"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Pushed this as a hotfix to v1.0.1, but now realize it's kind of stupid. It doesn't break any functionality, but it adds a method to the interface that just routes to another function. A better fix would've been to just change the code in the backtester instead of adding compatibility here.